### PR TITLE
Database migrations

### DIFF
--- a/bin/migrations-new
+++ b/bin/migrations-new
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+set -e
+
+if [ $# -lt 1 ]; then
+  echo "USAGE: bin/migrations-new <description>"
+  exit 1
+fi
+
+description="$*"
+description=$(echo $description | tr '[:upper:]' '[:lower:]')
+description=${description/ /_}
+
+timestamp=$(date +'%Y_%m_%d_%H%M%S')
+
+cat > "flask_app/migrations/${timestamp}_${description}.py" <<EOF
+def up(conn):
+    pass
+
+def down(conn):
+    pass
+EOF

--- a/bin/migrations-new
+++ b/bin/migrations-new
@@ -14,9 +14,27 @@ description=${description/ /_}
 timestamp=$(date +'%Y_%m_%d_%H%M%S')
 
 cat > "flask_app/migrations/${timestamp}_${description}.py" <<EOF
+import sqlalchemy as sql
+
 def up(conn):
-    pass
+    query = """
+
+    """
+    params = {}
+
+    conn.execute(sql.text(query), params)
+
 
 def down(conn):
-    pass
+    query = """
+
+    """
+    params = {}
+
+    conn.execute(sql.text(query), params)
+
+
+if __name__ == "__main__":
+    from flask_app.lib.migrations import run
+    run(__file__)
 EOF

--- a/bin/migrations-new
+++ b/bin/migrations-new
@@ -36,5 +36,5 @@ def down(conn):
 
 if __name__ == "__main__":
     from flask_app.lib.migrations import run
-    run(__file__)
+    run(__file__, up, down)
 EOF

--- a/bin/migrations-run
+++ b/bin/migrations-run
@@ -1,0 +1,34 @@
+#! /usr/bin/env python3
+
+import os
+import sys
+from pathlib import Path
+from importlib import import_module
+
+import sqlalchemy as sql
+
+from flask_app.db import get_connection
+from flask_app.lib.migrations import run
+
+def main():
+    migration_dir = os.path.abspath(f"{os.path.dirname(__file__)}/../flask_app/migrations")
+    migration_files = Path(migration_dir).glob('*.py')
+    migration_names = {path.stem for path in migration_files}
+
+    with get_connection() as conn:
+        query = "SELECT name FROM MigrationVersions WHERE migratedAt IS NOT NULL"
+        finished_migrations = {name for (name,) in conn.execute(sql.text(query)).all()}
+
+        pending_migrations = migration_names - finished_migrations
+
+        if len(pending_migrations) == 0:
+            print("Database up-to-date, nothing to do")
+            return
+
+        for name in sorted(pending_migrations):
+            migration_module = import_module(f"flask_app.migrations.{name}")
+            run(migration_module.__file__, migration_module.up, migration_module.down)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/migrations-run
+++ b/bin/migrations-run
@@ -17,9 +17,8 @@ def main():
 
     with get_connection() as conn:
         query = "SELECT name FROM MigrationVersions WHERE migratedAt IS NOT NULL"
-        finished_migrations = {name for (name,) in conn.execute(sql.text(query)).all()}
-
-        pending_migrations = migration_names - finished_migrations
+        applied_migrations = {name for (name,) in conn.execute(sql.text(query)).all()}
+        pending_migrations = migration_names - applied_migrations
 
         if len(pending_migrations) == 0:
             print("Database up-to-date, nothing to do")

--- a/flask_app/lib/migrations.py
+++ b/flask_app/lib/migrations.py
@@ -54,13 +54,16 @@ def run(file, up, down):
             raise ValueError(f"Unknown migration direction: {direction}")
 
     # Dump database snapshot into flask_app/schema.sql
-    with open('flask_app/schema.sql', 'w') as schema_file:
-        config = get_config()
+    schema_path = 'flask_app/schema.sql'
+    db_config = get_config()
+
+    with open(schema_path, 'w') as f:
+        print(f"> Dumping schema in {schema_path}...")
         subprocess.run([
             '/usr/bin/mysqldump',
             '--no-data',
-            f'-h{config["host"]}',
-            f'-u{config["username"]}',
-            f'-p{config["password"]}',
-            config['database']
-        ], stdout=schema_file)
+            f'-h{db_config["host"]}',
+            f'-u{db_config["username"]}',
+            f'-p{db_config["password"]}',
+            db_config['database']
+        ], stdout=f, stderr=subprocess.DEVNULL)

--- a/flask_app/lib/migrations.py
+++ b/flask_app/lib/migrations.py
@@ -1,0 +1,66 @@
+import sys
+import subprocess
+from pathlib import Path
+
+import sqlalchemy as sql
+
+from flask_app.db import get_connection, get_config
+
+def run(file, up, down):
+    migration_name = Path(file).stem
+    direction = sys.argv[1] if len(sys.argv) > 1 else "up"
+
+    with get_connection() as conn:
+        # Bootstrap first migration
+        conn.execute(sql.text("""
+            CREATE TABLE IF NOT EXISTS MigrationVersions (
+                id         BIGINT AUTO_INCREMENT,
+                name       VARCHAR(255),
+                migratedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+                PRIMARY KEY (id)
+            );
+        """))
+        conn.commit()
+
+        migrated_at = conn.execute(
+            sql.text('SELECT migratedAt FROM MigrationVersions WHERE name = :name'),
+            { 'name': migration_name },
+        ).scalar()
+
+        if direction == "up":
+            if migrated_at is None:
+                print(f"> Migrating {migration_name}...")
+                up(conn)
+                conn.execute(
+                    sql.text("INSERT INTO MigrationVersions (name) VALUES (:name)"),
+                    {'name': migration_name},
+                )
+                conn.commit()
+            else:
+                print(f"> Skipping migration {migration_name}, run at {migrated_at}")
+        elif direction == "down":
+            if migrated_at is None:
+                print(f"> Skipping {migration_name}, not run")
+            else:
+                print(f"> Rolling back {migration_name}...")
+                down(conn)
+                conn.execute(
+                    sql.text("DELETE FROM MigrationVersions WHERE name = :name"),
+                    {'name': migration_name},
+                )
+                conn.commit()
+        else:
+            raise ValueError(f"Unknown migration direction: {direction}")
+
+    # Dump database snapshot into flask_app/schema.sql
+    with open('flask_app/schema.sql', 'w') as schema_file:
+        config = get_config()
+        subprocess.run([
+            '/usr/bin/mysqldump',
+            '--no-data',
+            f'-h{config["host"]}',
+            f'-u{config["username"]}',
+            f'-p{config["password"]}',
+            config['database']
+        ], stdout=schema_file)

--- a/flask_app/migrations/000_initial_schema.sql
+++ b/flask_app/migrations/000_initial_schema.sql
@@ -1,5 +1,3 @@
--- TODO: Change all INT primary keys to BIGINT
-
 CREATE TABLE IF NOT EXISTS Project (
     projectId VARCHAR(100),
     projectName VARCHAR(100) DEFAULT NULL,
@@ -59,7 +57,7 @@ CREATE TABLE IF NOT EXISTS Compartments (
     FOREIGN KEY (studyId) REFERENCES Study (studyId) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE Strains (
+CREATE TABLE IF NOT EXISTS Strains (
     studyId VARCHAR(100),
     memberId VARCHAR(50),
     defined BOOLEAN DEFAULT FALSE,
@@ -93,18 +91,7 @@ CREATE TABLE IF NOT EXISTS Taxa (
     PRIMARY KEY (tax_id)
 );
 
-/*
-CREATE TABLE IF NOT EXISTS MetaboliteSynonym (
-    syn_id INT AUTO_INCREMENT PRIMARY KEY,
-    synonym_value VARCHAR(255) DEFAULT NULL,
-    cheb_id VARCHAR(255),
-    FOREIGN KEY (cheb_id) REFERENCES Metabolites(cheb_id)
-);
-
- */
-
-
-CREATE TABLE CompartmentsPerExperiment (
+CREATE TABLE IF NOT EXISTS CompartmentsPerExperiment (
     studyId VARCHAR(100),
     experimentUniqueId INT,
     experimentId VARCHAR(100) NOT NULL,
@@ -120,7 +107,7 @@ CREATE TABLE CompartmentsPerExperiment (
 );
 
 
-CREATE TABLE TechniquesPerExperiment (
+CREATE TABLE IF NOT EXISTS TechniquesPerExperiment (
     studyId VARCHAR(100),
     experimentUniqueId INT,
     experimentId VARCHAR(100) NOT NULL,
@@ -131,7 +118,7 @@ CREATE TABLE TechniquesPerExperiment (
     FOREIGN KEY (studyId) REFERENCES Study (studyId) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE BioReplicatesPerExperiment (
+CREATE TABLE IF NOT EXISTS BioReplicatesPerExperiment (
     studyId VARCHAR(100) NOT NULL,
     bioreplicateUniqueId INT AUTO_INCREMENT PRIMARY KEY,
     bioreplicateId VARCHAR(100),
@@ -148,7 +135,7 @@ CREATE TABLE BioReplicatesPerExperiment (
     FOREIGN KEY (studyId) REFERENCES Study (studyId)  ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE BioReplicatesMetadata (
+CREATE TABLE IF NOT EXISTS BioReplicatesMetadata (
     studyId VARCHAR(100) NOT NULL,
     bioreplicateUniqueId INT,
     bioreplicateId VARCHAR(100),

--- a/flask_app/migrations/2024_11_11_160324_initial_schema.py
+++ b/flask_app/migrations/2024_11_11_160324_initial_schema.py
@@ -32,34 +32,5 @@ def down(conn):
     """))
 
 if __name__ == "__main__":
-    import sqlalchemy as sql
-    from flask_app.db import get_connection
-
-    with get_connection() as conn:
-        # Bootstrap first migration
-        conn.execute(sql.text("""
-            CREATE TABLE IF NOT EXISTS MigrationVersions (
-                id         BIGINT AUTO_INCREMENT,
-                name       VARCHAR(255),
-                migratedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-
-                PRIMARY KEY (id)
-            );
-        """))
-        conn.commit()
-
-        migration_name = Path(__file__).stem
-        migrated_at = conn.execute(
-            sql.text('SELECT migratedAt FROM MigrationVersions WHERE name = :name'),
-            { 'name': migration_name },
-        ).scalar()
-
-        if migrated_at is not None:
-            print(f"> Skipping migration {migration_name}, run at {migrated_at}")
-        else:
-            up(conn)
-            conn.execute(
-                sql.text("INSERT INTO MigrationVersions (name) VALUES (:name)"),
-                {'name': migration_name},
-            )
-            conn.commit()
+    from flask_app.lib.migrations import run
+    run(__file__)

--- a/flask_app/migrations/2024_11_11_160324_initial_schema.py
+++ b/flask_app/migrations/2024_11_11_160324_initial_schema.py
@@ -1,0 +1,65 @@
+import os
+from pathlib import Path
+
+def up(conn):
+    initial_schema_file = Path(os.path.dirname(__file__)) / '000_initial_schema.sql'
+    initial_schema = initial_schema_file.read_text()
+
+    for statement in initial_schema.split(';'):
+        statement = statement.strip()
+        if len(statement) > 0:
+            conn.execute(sql.text(statement))
+
+def down(conn):
+    conn.execute(sql.text("""
+        DROP TABLE Project;
+        DROP TABLE Study;
+        DROP TABLE Experiments;
+        DROP TABLE Compartments;
+        DROP TABLE Strains;
+        DROP TABLE Community;
+        DROP TABLE Metabolites;
+        DROP TABLE Taxa;
+        DROP TABLE MetaboliteSynonym;
+        DROP TABLE CompartmentsPerExperiment;
+        DROP TABLE TechniquesPerExperiment;
+        DROP TABLE BioReplicatesPerExperiment;
+        DROP TABLE BioReplicatesMetadata;
+        DROP TABLE Perturbation;
+        DROP TABLE MetabolitePerExperiment;
+        DROP TABLE Abundances;
+        DROP TABLE FC_Counts;
+    """))
+
+if __name__ == "__main__":
+    import sqlalchemy as sql
+    from flask_app.db import get_connection
+
+    with get_connection() as conn:
+        # Bootstrap first migration
+        conn.execute(sql.text("""
+            CREATE TABLE IF NOT EXISTS MigrationVersions (
+                id         BIGINT AUTO_INCREMENT,
+                name       VARCHAR(255),
+                migratedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+                PRIMARY KEY (id)
+            );
+        """))
+        conn.commit()
+
+        migration_name = Path(__file__).stem
+        migrated_at = conn.execute(
+            sql.text('SELECT migratedAt FROM MigrationVersions WHERE name = :name'),
+            { 'name': migration_name },
+        ).scalar()
+
+        if migrated_at is not None:
+            print(f"> Skipping migration {migration_name}, run at {migrated_at}")
+        else:
+            up(conn)
+            conn.execute(
+                sql.text("INSERT INTO MigrationVersions (name) VALUES (:name)"),
+                {'name': migration_name},
+            )
+            conn.commit()

--- a/flask_app/migrations/2024_11_11_160324_initial_schema.py
+++ b/flask_app/migrations/2024_11_11_160324_initial_schema.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+import sqlalchemy as sql
+
 def up(conn):
     initial_schema_file = Path(os.path.dirname(__file__)) / '000_initial_schema.sql'
     initial_schema = initial_schema_file.read_text()
@@ -11,26 +13,8 @@ def up(conn):
             conn.execute(sql.text(statement))
 
 def down(conn):
-    conn.execute(sql.text("""
-        DROP TABLE Project;
-        DROP TABLE Study;
-        DROP TABLE Experiments;
-        DROP TABLE Compartments;
-        DROP TABLE Strains;
-        DROP TABLE Community;
-        DROP TABLE Metabolites;
-        DROP TABLE Taxa;
-        DROP TABLE MetaboliteSynonym;
-        DROP TABLE CompartmentsPerExperiment;
-        DROP TABLE TechniquesPerExperiment;
-        DROP TABLE BioReplicatesPerExperiment;
-        DROP TABLE BioReplicatesMetadata;
-        DROP TABLE Perturbation;
-        DROP TABLE MetabolitePerExperiment;
-        DROP TABLE Abundances;
-        DROP TABLE FC_Counts;
-    """))
+    pass
 
 if __name__ == "__main__":
     from flask_app.lib.migrations import run
-    run(__file__)
+    run(__file__, up, down)

--- a/flask_app/migrations/2024_11_11_164726_remove_unique_study_description_index.py
+++ b/flask_app/migrations/2024_11_11_164726_remove_unique_study_description_index.py
@@ -1,0 +1,21 @@
+import sqlalchemy as sql
+
+def up(conn):
+    query = """
+        ALTER TABLE Study
+        DROP INDEX studyDescription;
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE Study
+        ADD UNIQUE INDEX (studyDescription(255));
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from flask_app.lib.migrations import run
+    run(__file__, up, down)

--- a/flask_app/migrations/2024_11_21_115349_allow_null_medialink.py
+++ b/flask_app/migrations/2024_11_21_115349_allow_null_medialink.py
@@ -1,0 +1,23 @@
+import sqlalchemy as sql
+
+def up(conn):
+    query = """
+        ALTER TABLE Compartments
+        MODIFY COLUMN mediaLink
+        VARCHAR(100);
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE Compartments
+        MODIFY COLUMN mediaLink
+        VARCHAR(100) NOT NULL;
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from flask_app.lib.migrations import run
+    run(__file__, up, down)

--- a/flask_app/migrations/2024_11_21_120444_fix_unique_primary_keys.py
+++ b/flask_app/migrations/2024_11_21_120444_fix_unique_primary_keys.py
@@ -1,0 +1,37 @@
+import sqlalchemy as sql
+
+def up(conn):
+    query = """
+        ALTER TABLE MetabolitePerExperiment
+        DROP PRIMARY KEY,
+        ADD PRIMARY key(experimentUniqueId, bioreplicateUniqueId, cheb_id);
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE Abundances
+        DROP PRIMARY KEY,
+        ADD PRIMARY key(experimentUniqueId, bioreplicateUniqueId, memberId);
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE MetabolitePerExperiment
+        DROP PRIMARY KEY,
+        ADD PRIMARY key(experimentId, bioreplicateId, cheb_id);
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE Abundances
+        DROP PRIMARY KEY,
+        ADD PRIMARY key(experimentId, bioreplicateId, memberId);
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from flask_app.lib.migrations import run
+    run(__file__, up, down)

--- a/flask_app/schema.sql
+++ b/flask_app/schema.sql
@@ -263,7 +263,7 @@ CREATE TABLE `MigrationVersions` (
   `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `migratedAt` datetime DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -395,4 +395,4 @@ CREATE TABLE `TechniquesPerExperiment` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2024-11-11 17:09:21
+-- Dump completed on 2024-11-14 11:12:34

--- a/flask_app/schema.sql
+++ b/flask_app/schema.sql
@@ -1,0 +1,398 @@
+-- MySQL dump 10.13  Distrib 8.4.0, for Linux (x86_64)
+--
+-- Host: localhost    Database: BacterialGrowth
+-- ------------------------------------------------------
+-- Server version	8.4.0
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `Abundances`
+--
+
+DROP TABLE IF EXISTS `Abundances`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Abundances` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int DEFAULT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `bioreplicateUniqueId` int DEFAULT NULL,
+  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `strainId` int DEFAULT NULL,
+  `memberId` varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`experimentId`,`bioreplicateId`,`memberId`),
+  KEY `fk_1` (`experimentUniqueId`),
+  KEY `fk_2` (`strainId`),
+  KEY `fk_3` (`studyId`),
+  CONSTRAINT `Abundances_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `Abundances_fk_2` FOREIGN KEY (`strainId`) REFERENCES `Strains` (`strainId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `Abundances_fk_3` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `BioReplicatesMetadata`
+--
+
+DROP TABLE IF EXISTS `BioReplicatesMetadata`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `BioReplicatesMetadata` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `bioreplicateUniqueId` int DEFAULT NULL,
+  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `biosampleLink` text COLLATE utf8mb4_bin,
+  `bioreplicateDescrition` text COLLATE utf8mb4_bin,
+  PRIMARY KEY (`bioreplicateId`),
+  UNIQUE KEY `studyId` (`studyId`,`bioreplicateUniqueId`),
+  KEY `fk_1` (`bioreplicateUniqueId`),
+  CONSTRAINT `BioReplicatesMetadata_fk_1` FOREIGN KEY (`bioreplicateUniqueId`) REFERENCES `BioReplicatesPerExperiment` (`bioreplicateUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `BioReplicatesMetadata_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `BioReplicatesPerExperiment`
+--
+
+DROP TABLE IF EXISTS `BioReplicatesPerExperiment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `BioReplicatesPerExperiment` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `bioreplicateUniqueId` int NOT NULL AUTO_INCREMENT,
+  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int DEFAULT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `controls` tinyint(1) DEFAULT '0',
+  `OD` tinyint(1) DEFAULT '0',
+  `OD_std` tinyint(1) DEFAULT '0',
+  `Plate_counts` tinyint(1) DEFAULT '0',
+  `Plate_counts_std` tinyint(1) DEFAULT '0',
+  `pH` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`bioreplicateUniqueId`),
+  UNIQUE KEY `studyId` (`studyId`,`bioreplicateId`),
+  KEY `fk_1` (`experimentUniqueId`),
+  CONSTRAINT `BioReplicatesPerExperiment_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `BioReplicatesPerExperiment_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=60007 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Community`
+--
+
+DROP TABLE IF EXISTS `Community`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Community` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `comunityUniqueId` int NOT NULL AUTO_INCREMENT,
+  `comunityId` varchar(50) COLLATE utf8mb4_bin NOT NULL,
+  `strainId` int DEFAULT NULL,
+  PRIMARY KEY (`comunityUniqueId`),
+  UNIQUE KEY `comunityId` (`comunityId`,`strainId`),
+  KEY `fk_1` (`strainId`),
+  KEY `fk_2` (`studyId`),
+  CONSTRAINT `Community_fk_1` FOREIGN KEY (`strainId`) REFERENCES `Strains` (`strainId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `Community_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=60007 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Compartments`
+--
+
+DROP TABLE IF EXISTS `Compartments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Compartments` (
+  `compartmentUniqueId` int NOT NULL AUTO_INCREMENT,
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `compartmentId` varchar(50) COLLATE utf8mb4_bin NOT NULL,
+  `volume` float(7,2) DEFAULT '0.00',
+  `pressure` float(7,2) DEFAULT '0.00',
+  `stirring_speed` float(7,2) DEFAULT '0.00',
+  `stirring_mode` varchar(50) COLLATE utf8mb4_bin DEFAULT '',
+  `O2` float(7,2) DEFAULT '0.00',
+  `CO2` float(7,2) DEFAULT '0.00',
+  `H2` float(7,2) DEFAULT '0.00',
+  `N2` float(7,2) DEFAULT '0.00',
+  `inoculumConcentration` float(10,2) DEFAULT '0.00',
+  `inoculumVolume` float(7,2) DEFAULT '0.00',
+  `initialPh` float(7,2) DEFAULT '0.00',
+  `initialTemperature` float(7,2) DEFAULT '0.00',
+  `carbonSource` tinyint(1) DEFAULT '0',
+  `mediaNames` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `mediaLink` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`compartmentUniqueId`),
+  KEY `fk_1` (`studyId`),
+  CONSTRAINT `Compartments_fk_1` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=60002 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `CompartmentsPerExperiment`
+--
+
+DROP TABLE IF EXISTS `CompartmentsPerExperiment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `CompartmentsPerExperiment` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int NOT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `compartmentUniqueId` int NOT NULL,
+  `compartmentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `comunityUniqueId` int NOT NULL,
+  `comunityId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`experimentUniqueId`,`compartmentUniqueId`,`comunityUniqueId`),
+  KEY `fk_2` (`compartmentUniqueId`),
+  KEY `fk_3` (`comunityUniqueId`),
+  KEY `fk_4` (`studyId`),
+  CONSTRAINT `CompartmentsPerExperiment_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `CompartmentsPerExperiment_fk_2` FOREIGN KEY (`compartmentUniqueId`) REFERENCES `Compartments` (`compartmentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `CompartmentsPerExperiment_fk_3` FOREIGN KEY (`comunityUniqueId`) REFERENCES `Community` (`comunityUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `CompartmentsPerExperiment_fk_4` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Experiments`
+--
+
+DROP TABLE IF EXISTS `Experiments`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Experiments` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int NOT NULL AUTO_INCREMENT,
+  `experimentId` varchar(20) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentDescription` text COLLATE utf8mb4_bin,
+  `cultivationMode` varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
+  `controlDescription` text COLLATE utf8mb4_bin,
+  PRIMARY KEY (`experimentUniqueId`),
+  KEY `fk_1` (`studyId`),
+  CONSTRAINT `Experiments_fk_1` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=60003 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `FC_Counts`
+--
+
+DROP TABLE IF EXISTS `FC_Counts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `FC_Counts` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int DEFAULT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `bioreplicateUniqueId` int DEFAULT NULL,
+  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `strainId` int DEFAULT NULL,
+  `memberId` varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`experimentId`,`bioreplicateId`,`memberId`),
+  KEY `fk_1` (`experimentUniqueId`),
+  KEY `fk_2` (`strainId`),
+  KEY `fk_3` (`studyId`),
+  CONSTRAINT `FC_Counts_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FC_Counts_fk_2` FOREIGN KEY (`strainId`) REFERENCES `Strains` (`strainId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FC_Counts_fk_3` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `MetabolitePerExperiment`
+--
+
+DROP TABLE IF EXISTS `MetabolitePerExperiment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `MetabolitePerExperiment` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int DEFAULT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `bioreplicateUniqueId` int DEFAULT NULL,
+  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `metabo_name` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  `cheb_id` varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`experimentId`,`bioreplicateId`,`cheb_id`),
+  KEY `fk_1` (`cheb_id`),
+  KEY `fk_2` (`experimentUniqueId`),
+  KEY `fk_3` (`studyId`),
+  CONSTRAINT `MetabolitePerExperiment_fk_1` FOREIGN KEY (`cheb_id`) REFERENCES `Metabolites` (`cheb_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `MetabolitePerExperiment_fk_2` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `MetabolitePerExperiment_fk_3` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Metabolites`
+--
+
+DROP TABLE IF EXISTS `Metabolites`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Metabolites` (
+  `cheb_id` varchar(512) COLLATE utf8mb4_bin NOT NULL,
+  `metabo_name` varchar(512) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (`cheb_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `MigrationVersions`
+--
+
+DROP TABLE IF EXISTS `MigrationVersions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `MigrationVersions` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `migratedAt` datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Perturbation`
+--
+
+DROP TABLE IF EXISTS `Perturbation`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Perturbation` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `perturbationUniqueid` int NOT NULL AUTO_INCREMENT,
+  `perturbationId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `experimentUniqueId` int DEFAULT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `OLDCompartmentId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `OLDComunityId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `NEWCompartmentId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `NEWComunityId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `perturbationDescription` text COLLATE utf8mb4_bin,
+  `perturbationMinimumValue` decimal(10,2) DEFAULT NULL,
+  `perturbationMaximumValue` decimal(10,2) DEFAULT NULL,
+  `perturbationStartTime` time DEFAULT NULL,
+  `perturbationEndTime` time DEFAULT NULL,
+  PRIMARY KEY (`perturbationUniqueid`),
+  KEY `fk_1` (`experimentUniqueId`),
+  KEY `fk_2` (`studyId`),
+  CONSTRAINT `Perturbation_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `Perturbation_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Project`
+--
+
+DROP TABLE IF EXISTS `Project`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Project` (
+  `projectId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `projectName` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `projectDescription` text COLLATE utf8mb4_bin,
+  `projectUniqueID` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (`projectId`),
+  UNIQUE KEY `projectName` (`projectName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Strains`
+--
+
+DROP TABLE IF EXISTS `Strains`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Strains` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `memberId` varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
+  `defined` tinyint(1) DEFAULT '0',
+  `memberName` text COLLATE utf8mb4_bin,
+  `strainId` int NOT NULL AUTO_INCREMENT,
+  `NCBId` int DEFAULT NULL,
+  `descriptionMember` text COLLATE utf8mb4_bin,
+  PRIMARY KEY (`strainId`),
+  KEY `fk_1` (`studyId`),
+  CONSTRAINT `Strains_fk_1` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=60006 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Study`
+--
+
+DROP TABLE IF EXISTS `Study`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Study` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `projectUniqueID` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `studyName` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `studyDescription` text COLLATE utf8mb4_bin,
+  `studyURL` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `studyUniqueID` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (`studyId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `Taxa`
+--
+
+DROP TABLE IF EXISTS `Taxa`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `Taxa` (
+  `tax_id` varchar(512) COLLATE utf8mb4_bin NOT NULL,
+  `tax_names` varchar(512) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (`tax_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `TechniquesPerExperiment`
+--
+
+DROP TABLE IF EXISTS `TechniquesPerExperiment`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `TechniquesPerExperiment` (
+  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  `experimentUniqueId` int NOT NULL,
+  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `technique` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  `techniqueUnit` varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (`experimentUniqueId`,`technique`,`techniqueUnit`),
+  KEY `fk_2` (`studyId`),
+  CONSTRAINT `TechniquesPerExperiment_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `TechniquesPerExperiment_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2024-11-11 17:09:21

--- a/flask_app/schema.sql
+++ b/flask_app/schema.sql
@@ -19,24 +19,24 @@
 -- Table structure for table `Abundances`
 --
 
-DROP TABLE IF EXISTS `Abundances`;
+DROP TABLE IF EXISTS Abundances;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Abundances` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int DEFAULT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `bioreplicateUniqueId` int DEFAULT NULL,
-  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `strainId` int DEFAULT NULL,
-  `memberId` varchar(255) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (`experimentId`,`bioreplicateId`,`memberId`),
-  KEY `fk_1` (`experimentUniqueId`),
-  KEY `fk_2` (`strainId`),
-  KEY `fk_3` (`studyId`),
-  CONSTRAINT `Abundances_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Abundances_fk_2` FOREIGN KEY (`strainId`) REFERENCES `Strains` (`strainId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Abundances_fk_3` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE Abundances (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int DEFAULT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  bioreplicateUniqueId int DEFAULT NULL,
+  bioreplicateId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  strainId int DEFAULT NULL,
+  memberId varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (experimentId,bioreplicateId,memberId),
+  KEY fk_1 (experimentUniqueId),
+  KEY fk_2 (strainId),
+  KEY fk_3 (studyId),
+  CONSTRAINT Abundances_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT Abundances_fk_2 FOREIGN KEY (strainId) REFERENCES Strains (strainId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT Abundances_fk_3 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -44,20 +44,20 @@ CREATE TABLE `Abundances` (
 -- Table structure for table `BioReplicatesMetadata`
 --
 
-DROP TABLE IF EXISTS `BioReplicatesMetadata`;
+DROP TABLE IF EXISTS BioReplicatesMetadata;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `BioReplicatesMetadata` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `bioreplicateUniqueId` int DEFAULT NULL,
-  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `biosampleLink` text COLLATE utf8mb4_bin,
-  `bioreplicateDescrition` text COLLATE utf8mb4_bin,
-  PRIMARY KEY (`bioreplicateId`),
-  UNIQUE KEY `studyId` (`studyId`,`bioreplicateUniqueId`),
-  KEY `fk_1` (`bioreplicateUniqueId`),
-  CONSTRAINT `BioReplicatesMetadata_fk_1` FOREIGN KEY (`bioreplicateUniqueId`) REFERENCES `BioReplicatesPerExperiment` (`bioreplicateUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `BioReplicatesMetadata_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE BioReplicatesMetadata (
+  studyId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  bioreplicateUniqueId int DEFAULT NULL,
+  bioreplicateId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  biosampleLink text COLLATE utf8mb4_bin,
+  bioreplicateDescrition text COLLATE utf8mb4_bin,
+  PRIMARY KEY (bioreplicateId),
+  UNIQUE KEY studyId (studyId,bioreplicateUniqueId),
+  KEY fk_1 (bioreplicateUniqueId),
+  CONSTRAINT BioReplicatesMetadata_fk_1 FOREIGN KEY (bioreplicateUniqueId) REFERENCES BioReplicatesPerExperiment (bioreplicateUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT BioReplicatesMetadata_fk_2 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -65,105 +65,105 @@ CREATE TABLE `BioReplicatesMetadata` (
 -- Table structure for table `BioReplicatesPerExperiment`
 --
 
-DROP TABLE IF EXISTS `BioReplicatesPerExperiment`;
+DROP TABLE IF EXISTS BioReplicatesPerExperiment;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `BioReplicatesPerExperiment` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `bioreplicateUniqueId` int NOT NULL AUTO_INCREMENT,
-  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int DEFAULT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `controls` tinyint(1) DEFAULT '0',
-  `OD` tinyint(1) DEFAULT '0',
-  `OD_std` tinyint(1) DEFAULT '0',
-  `Plate_counts` tinyint(1) DEFAULT '0',
-  `Plate_counts_std` tinyint(1) DEFAULT '0',
-  `pH` tinyint(1) DEFAULT '0',
-  PRIMARY KEY (`bioreplicateUniqueId`),
-  UNIQUE KEY `studyId` (`studyId`,`bioreplicateId`),
-  KEY `fk_1` (`experimentUniqueId`),
-  CONSTRAINT `BioReplicatesPerExperiment_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `BioReplicatesPerExperiment_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=60007 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE BioReplicatesPerExperiment (
+  studyId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  bioreplicateUniqueId int NOT NULL AUTO_INCREMENT,
+  bioreplicateId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int DEFAULT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  controls tinyint(1) DEFAULT '0',
+  OD tinyint(1) DEFAULT '0',
+  OD_std tinyint(1) DEFAULT '0',
+  Plate_counts tinyint(1) DEFAULT '0',
+  Plate_counts_std tinyint(1) DEFAULT '0',
+  pH tinyint(1) DEFAULT '0',
+  PRIMARY KEY (bioreplicateUniqueId),
+  UNIQUE KEY studyId (studyId,bioreplicateId),
+  KEY fk_1 (experimentUniqueId),
+  CONSTRAINT BioReplicatesPerExperiment_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT BioReplicatesPerExperiment_fk_2 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `Community`
 --
 
-DROP TABLE IF EXISTS `Community`;
+DROP TABLE IF EXISTS Community;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Community` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `comunityUniqueId` int NOT NULL AUTO_INCREMENT,
-  `comunityId` varchar(50) COLLATE utf8mb4_bin NOT NULL,
-  `strainId` int DEFAULT NULL,
-  PRIMARY KEY (`comunityUniqueId`),
-  UNIQUE KEY `comunityId` (`comunityId`,`strainId`),
-  KEY `fk_1` (`strainId`),
-  KEY `fk_2` (`studyId`),
-  CONSTRAINT `Community_fk_1` FOREIGN KEY (`strainId`) REFERENCES `Strains` (`strainId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Community_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=60007 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE Community (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  comunityUniqueId int NOT NULL AUTO_INCREMENT,
+  comunityId varchar(50) COLLATE utf8mb4_bin NOT NULL,
+  strainId int DEFAULT NULL,
+  PRIMARY KEY (comunityUniqueId),
+  UNIQUE KEY comunityId (comunityId,strainId),
+  KEY fk_1 (strainId),
+  KEY fk_2 (studyId),
+  CONSTRAINT Community_fk_1 FOREIGN KEY (strainId) REFERENCES Strains (strainId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT Community_fk_2 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `Compartments`
 --
 
-DROP TABLE IF EXISTS `Compartments`;
+DROP TABLE IF EXISTS Compartments;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Compartments` (
-  `compartmentUniqueId` int NOT NULL AUTO_INCREMENT,
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `compartmentId` varchar(50) COLLATE utf8mb4_bin NOT NULL,
-  `volume` float(7,2) DEFAULT '0.00',
-  `pressure` float(7,2) DEFAULT '0.00',
-  `stirring_speed` float(7,2) DEFAULT '0.00',
-  `stirring_mode` varchar(50) COLLATE utf8mb4_bin DEFAULT '',
-  `O2` float(7,2) DEFAULT '0.00',
-  `CO2` float(7,2) DEFAULT '0.00',
-  `H2` float(7,2) DEFAULT '0.00',
-  `N2` float(7,2) DEFAULT '0.00',
-  `inoculumConcentration` float(10,2) DEFAULT '0.00',
-  `inoculumVolume` float(7,2) DEFAULT '0.00',
-  `initialPh` float(7,2) DEFAULT '0.00',
-  `initialTemperature` float(7,2) DEFAULT '0.00',
-  `carbonSource` tinyint(1) DEFAULT '0',
-  `mediaNames` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `mediaLink` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (`compartmentUniqueId`),
-  KEY `fk_1` (`studyId`),
-  CONSTRAINT `Compartments_fk_1` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=60002 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE Compartments (
+  compartmentUniqueId int NOT NULL AUTO_INCREMENT,
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  compartmentId varchar(50) COLLATE utf8mb4_bin NOT NULL,
+  volume float(7,2) DEFAULT '0.00',
+  pressure float(7,2) DEFAULT '0.00',
+  stirring_speed float(7,2) DEFAULT '0.00',
+  stirring_mode varchar(50) COLLATE utf8mb4_bin DEFAULT '',
+  O2 float(7,2) DEFAULT '0.00',
+  CO2 float(7,2) DEFAULT '0.00',
+  H2 float(7,2) DEFAULT '0.00',
+  N2 float(7,2) DEFAULT '0.00',
+  inoculumConcentration float(10,2) DEFAULT '0.00',
+  inoculumVolume float(7,2) DEFAULT '0.00',
+  initialPh float(7,2) DEFAULT '0.00',
+  initialTemperature float(7,2) DEFAULT '0.00',
+  carbonSource tinyint(1) DEFAULT '0',
+  mediaNames varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  mediaLink varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (compartmentUniqueId),
+  KEY fk_1 (studyId),
+  CONSTRAINT Compartments_fk_1 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `CompartmentsPerExperiment`
 --
 
-DROP TABLE IF EXISTS `CompartmentsPerExperiment`;
+DROP TABLE IF EXISTS CompartmentsPerExperiment;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `CompartmentsPerExperiment` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int NOT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `compartmentUniqueId` int NOT NULL,
-  `compartmentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `comunityUniqueId` int NOT NULL,
-  `comunityId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (`experimentUniqueId`,`compartmentUniqueId`,`comunityUniqueId`),
-  KEY `fk_2` (`compartmentUniqueId`),
-  KEY `fk_3` (`comunityUniqueId`),
-  KEY `fk_4` (`studyId`),
-  CONSTRAINT `CompartmentsPerExperiment_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `CompartmentsPerExperiment_fk_2` FOREIGN KEY (`compartmentUniqueId`) REFERENCES `Compartments` (`compartmentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `CompartmentsPerExperiment_fk_3` FOREIGN KEY (`comunityUniqueId`) REFERENCES `Community` (`comunityUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `CompartmentsPerExperiment_fk_4` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE CompartmentsPerExperiment (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int NOT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  compartmentUniqueId int NOT NULL,
+  compartmentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  comunityUniqueId int NOT NULL,
+  comunityId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (experimentUniqueId,compartmentUniqueId,comunityUniqueId),
+  KEY fk_2 (compartmentUniqueId),
+  KEY fk_3 (comunityUniqueId),
+  KEY fk_4 (studyId),
+  CONSTRAINT CompartmentsPerExperiment_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT CompartmentsPerExperiment_fk_2 FOREIGN KEY (compartmentUniqueId) REFERENCES Compartments (compartmentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT CompartmentsPerExperiment_fk_3 FOREIGN KEY (comunityUniqueId) REFERENCES Community (comunityUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT CompartmentsPerExperiment_fk_4 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -171,44 +171,44 @@ CREATE TABLE `CompartmentsPerExperiment` (
 -- Table structure for table `Experiments`
 --
 
-DROP TABLE IF EXISTS `Experiments`;
+DROP TABLE IF EXISTS Experiments;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Experiments` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int NOT NULL AUTO_INCREMENT,
-  `experimentId` varchar(20) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentDescription` text COLLATE utf8mb4_bin,
-  `cultivationMode` varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
-  `controlDescription` text COLLATE utf8mb4_bin,
-  PRIMARY KEY (`experimentUniqueId`),
-  KEY `fk_1` (`studyId`),
-  CONSTRAINT `Experiments_fk_1` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=60003 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE Experiments (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int NOT NULL AUTO_INCREMENT,
+  experimentId varchar(20) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentDescription text COLLATE utf8mb4_bin,
+  cultivationMode varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
+  controlDescription text COLLATE utf8mb4_bin,
+  PRIMARY KEY (experimentUniqueId),
+  KEY fk_1 (studyId),
+  CONSTRAINT Experiments_fk_1 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `FC_Counts`
 --
 
-DROP TABLE IF EXISTS `FC_Counts`;
+DROP TABLE IF EXISTS FC_Counts;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `FC_Counts` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int DEFAULT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `bioreplicateUniqueId` int DEFAULT NULL,
-  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `strainId` int DEFAULT NULL,
-  `memberId` varchar(255) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (`experimentId`,`bioreplicateId`,`memberId`),
-  KEY `fk_1` (`experimentUniqueId`),
-  KEY `fk_2` (`strainId`),
-  KEY `fk_3` (`studyId`),
-  CONSTRAINT `FC_Counts_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FC_Counts_fk_2` FOREIGN KEY (`strainId`) REFERENCES `Strains` (`strainId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FC_Counts_fk_3` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE FC_Counts (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int DEFAULT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  bioreplicateUniqueId int DEFAULT NULL,
+  bioreplicateId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  strainId int DEFAULT NULL,
+  memberId varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (experimentId,bioreplicateId,memberId),
+  KEY fk_1 (experimentUniqueId),
+  KEY fk_2 (strainId),
+  KEY fk_3 (studyId),
+  CONSTRAINT FC_Counts_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FC_Counts_fk_2 FOREIGN KEY (strainId) REFERENCES Strains (strainId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT FC_Counts_fk_3 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -216,24 +216,24 @@ CREATE TABLE `FC_Counts` (
 -- Table structure for table `MetabolitePerExperiment`
 --
 
-DROP TABLE IF EXISTS `MetabolitePerExperiment`;
+DROP TABLE IF EXISTS MetabolitePerExperiment;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `MetabolitePerExperiment` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int DEFAULT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `bioreplicateUniqueId` int DEFAULT NULL,
-  `bioreplicateId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `metabo_name` varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
-  `cheb_id` varchar(255) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (`experimentId`,`bioreplicateId`,`cheb_id`),
-  KEY `fk_1` (`cheb_id`),
-  KEY `fk_2` (`experimentUniqueId`),
-  KEY `fk_3` (`studyId`),
-  CONSTRAINT `MetabolitePerExperiment_fk_1` FOREIGN KEY (`cheb_id`) REFERENCES `Metabolites` (`cheb_id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `MetabolitePerExperiment_fk_2` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `MetabolitePerExperiment_fk_3` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE MetabolitePerExperiment (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int DEFAULT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  bioreplicateUniqueId int DEFAULT NULL,
+  bioreplicateId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  metabo_name varchar(255) COLLATE utf8mb4_bin DEFAULT NULL,
+  cheb_id varchar(255) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (experimentId,bioreplicateId,cheb_id),
+  KEY fk_1 (cheb_id),
+  KEY fk_2 (experimentUniqueId),
+  KEY fk_3 (studyId),
+  CONSTRAINT MetabolitePerExperiment_fk_1 FOREIGN KEY (cheb_id) REFERENCES Metabolites (cheb_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT MetabolitePerExperiment_fk_2 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT MetabolitePerExperiment_fk_3 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -241,13 +241,13 @@ CREATE TABLE `MetabolitePerExperiment` (
 -- Table structure for table `Metabolites`
 --
 
-DROP TABLE IF EXISTS `Metabolites`;
+DROP TABLE IF EXISTS Metabolites;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Metabolites` (
-  `cheb_id` varchar(512) COLLATE utf8mb4_bin NOT NULL,
-  `metabo_name` varchar(512) COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`cheb_id`)
+CREATE TABLE Metabolites (
+  cheb_id varchar(512) COLLATE utf8mb4_bin NOT NULL,
+  metabo_name varchar(512) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (cheb_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -255,44 +255,44 @@ CREATE TABLE `Metabolites` (
 -- Table structure for table `MigrationVersions`
 --
 
-DROP TABLE IF EXISTS `MigrationVersions`;
+DROP TABLE IF EXISTS MigrationVersions;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `MigrationVersions` (
-  `id` bigint NOT NULL AUTO_INCREMENT,
+CREATE TABLE MigrationVersions (
+  id bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `migratedAt` datetime DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  migratedAt datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `Perturbation`
 --
 
-DROP TABLE IF EXISTS `Perturbation`;
+DROP TABLE IF EXISTS Perturbation;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Perturbation` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `perturbationUniqueid` int NOT NULL AUTO_INCREMENT,
-  `perturbationId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `experimentUniqueId` int DEFAULT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `OLDCompartmentId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `OLDComunityId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `NEWCompartmentId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `NEWComunityId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `perturbationDescription` text COLLATE utf8mb4_bin,
-  `perturbationMinimumValue` decimal(10,2) DEFAULT NULL,
-  `perturbationMaximumValue` decimal(10,2) DEFAULT NULL,
-  `perturbationStartTime` time DEFAULT NULL,
-  `perturbationEndTime` time DEFAULT NULL,
-  PRIMARY KEY (`perturbationUniqueid`),
-  KEY `fk_1` (`experimentUniqueId`),
-  KEY `fk_2` (`studyId`),
-  CONSTRAINT `Perturbation_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Perturbation_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE Perturbation (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  perturbationUniqueid int NOT NULL AUTO_INCREMENT,
+  perturbationId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  experimentUniqueId int DEFAULT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  OLDCompartmentId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  OLDComunityId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  NEWCompartmentId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  NEWComunityId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  perturbationDescription text COLLATE utf8mb4_bin,
+  perturbationMinimumValue decimal(10,2) DEFAULT NULL,
+  perturbationMaximumValue decimal(10,2) DEFAULT NULL,
+  perturbationStartTime time DEFAULT NULL,
+  perturbationEndTime time DEFAULT NULL,
+  PRIMARY KEY (perturbationUniqueid),
+  KEY fk_1 (experimentUniqueId),
+  KEY fk_2 (studyId),
+  CONSTRAINT Perturbation_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT Perturbation_fk_2 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -300,16 +300,16 @@ CREATE TABLE `Perturbation` (
 -- Table structure for table `Project`
 --
 
-DROP TABLE IF EXISTS `Project`;
+DROP TABLE IF EXISTS Project;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Project` (
-  `projectId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `projectName` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `projectDescription` text COLLATE utf8mb4_bin,
-  `projectUniqueID` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`projectId`),
-  UNIQUE KEY `projectName` (`projectName`)
+CREATE TABLE Project (
+  projectId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  projectName varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  projectDescription text COLLATE utf8mb4_bin,
+  projectUniqueID varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (projectId),
+  UNIQUE KEY projectName (projectName)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -317,38 +317,38 @@ CREATE TABLE `Project` (
 -- Table structure for table `Strains`
 --
 
-DROP TABLE IF EXISTS `Strains`;
+DROP TABLE IF EXISTS Strains;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Strains` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `memberId` varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
-  `defined` tinyint(1) DEFAULT '0',
-  `memberName` text COLLATE utf8mb4_bin,
-  `strainId` int NOT NULL AUTO_INCREMENT,
-  `NCBId` int DEFAULT NULL,
-  `descriptionMember` text COLLATE utf8mb4_bin,
-  PRIMARY KEY (`strainId`),
-  KEY `fk_1` (`studyId`),
-  CONSTRAINT `Strains_fk_1` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=60006 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE Strains (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  memberId varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
+  defined tinyint(1) DEFAULT '0',
+  memberName text COLLATE utf8mb4_bin,
+  strainId int NOT NULL AUTO_INCREMENT,
+  NCBId int DEFAULT NULL,
+  descriptionMember text COLLATE utf8mb4_bin,
+  PRIMARY KEY (strainId),
+  KEY fk_1 (studyId),
+  CONSTRAINT Strains_fk_1 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `Study`
 --
 
-DROP TABLE IF EXISTS `Study`;
+DROP TABLE IF EXISTS Study;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Study` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `projectUniqueID` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `studyName` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `studyDescription` text COLLATE utf8mb4_bin,
-  `studyURL` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `studyUniqueID` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`studyId`)
+CREATE TABLE Study (
+  studyId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  projectUniqueID varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  studyName varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  studyDescription text COLLATE utf8mb4_bin,
+  studyURL varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  studyUniqueID varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (studyId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -356,13 +356,13 @@ CREATE TABLE `Study` (
 -- Table structure for table `Taxa`
 --
 
-DROP TABLE IF EXISTS `Taxa`;
+DROP TABLE IF EXISTS Taxa;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `Taxa` (
-  `tax_id` varchar(512) COLLATE utf8mb4_bin NOT NULL,
-  `tax_names` varchar(512) COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`tax_id`)
+CREATE TABLE Taxa (
+  tax_id varchar(512) COLLATE utf8mb4_bin NOT NULL,
+  tax_names varchar(512) COLLATE utf8mb4_bin DEFAULT NULL,
+  PRIMARY KEY (tax_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -370,19 +370,19 @@ CREATE TABLE `Taxa` (
 -- Table structure for table `TechniquesPerExperiment`
 --
 
-DROP TABLE IF EXISTS `TechniquesPerExperiment`;
+DROP TABLE IF EXISTS TechniquesPerExperiment;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `TechniquesPerExperiment` (
-  `studyId` varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  `experimentUniqueId` int NOT NULL,
-  `experimentId` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `technique` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  `techniqueUnit` varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (`experimentUniqueId`,`technique`,`techniqueUnit`),
-  KEY `fk_2` (`studyId`),
-  CONSTRAINT `TechniquesPerExperiment_fk_1` FOREIGN KEY (`experimentUniqueId`) REFERENCES `Experiments` (`experimentUniqueId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `TechniquesPerExperiment_fk_2` FOREIGN KEY (`studyId`) REFERENCES `Study` (`studyId`) ON DELETE CASCADE ON UPDATE CASCADE
+CREATE TABLE TechniquesPerExperiment (
+  studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentUniqueId int NOT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  technique varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  techniqueUnit varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (experimentUniqueId,technique,techniqueUnit),
+  KEY fk_2 (studyId),
+  CONSTRAINT TechniquesPerExperiment_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT TechniquesPerExperiment_fk_2 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -395,4 +395,6 @@ CREATE TABLE `TechniquesPerExperiment` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2024-11-14 11:12:34
+INSERT INTO MigrationVersions VALUES (8,'2024_11_11_160324_initial_schema','2024-11-14 11:12:21'),(9,'2024_11_11_164726_remove_unique_study_description_index','2024-11-14 11:12:33');
+
+-- Dump completed on 2024-11-14 12:23:49

--- a/flask_app/schema.sql
+++ b/flask_app/schema.sql
@@ -395,6 +395,6 @@ CREATE TABLE TechniquesPerExperiment (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-INSERT INTO MigrationVersions VALUES (8,'2024_11_11_160324_initial_schema','2024-11-14 11:12:21'),(9,'2024_11_11_164726_remove_unique_study_description_index','2024-11-14 11:12:33');
+INSERT INTO MigrationVersions VALUES (8,'2024_11_11_160324_initial_schema','2024-11-14 11:12:21'),(10,'2024_11_11_164726_remove_unique_study_description_index','2024-11-21 11:09:27');
 
--- Dump completed on 2024-11-14 12:23:49
+-- Dump completed on 2024-11-21 11:09:27


### PR DESCRIPTION
This PR implements database migrations, a way to make incremental changes to a database while hopefully keeping the data intact. Each migration has an "up" action that applies it and a "down" action that rolls it back.

The script `bin/migrations-new` creates a new empty migration with a filename that represents a timestamp, so it sorts chronologically.

The script `bin/migrations-run` is going to execute all migrations that haven't been run. The way that we keep track of that is by putting them in a `MigrationVersions` table. Executing an individual migration with `python <migration-file>.py <up|down>` should run this particular migration or roll it back. Ideally, when creating a new migration, you should try to run it both forward and back to make sure it doesn't blow up.

A full dump of the structure of the database and the migration versions is placed in `flask_app/schema.sql`. That way, we should always have an up-to-date snapshot that we can use to recreate an empty development database or a test database, or just to read the current structure. That file should be committed to the repository, so that checking out the code somewhere doesn't require running all migrations, but could just involve importing the snapshot.