### PR TITLE
Minor database-related fixes

### DIFF
--- a/bin/migrations-run
+++ b/bin/migrations-run
@@ -15,6 +15,11 @@ def main():
     migration_files = Path(migration_dir).glob('*.py')
     migration_names = {path.stem for path in migration_files}
 
+    direction = sys.argv[1] if len(sys.argv) > 1 else "up"
+    if direction not in ('up', 'down'):
+        print("Invalid migration direction: {direction}. Expected 'up' or 'down'")
+        sys.exit(1)
+
     with get_connection() as conn:
         # Bootstrap first migration
         conn.execute(sql.text("""
@@ -32,13 +37,23 @@ def main():
         applied_migrations = {name for (name,) in conn.execute(sql.text(query)).all()}
         pending_migrations = migration_names - applied_migrations
 
-        if len(pending_migrations) == 0:
-            print("Database up-to-date, nothing to do")
-            return
+        if direction == 'up':
+            if len(pending_migrations) == 0:
+                print("Database up-to-date, nothing to do")
+                return
 
-        for name in sorted(pending_migrations):
-            migration_module = import_module(f"db.migrations.{name}")
-            run(migration_module.__file__, migration_module.up, migration_module.down)
+            for name in sorted(pending_migrations):
+                migration_module = import_module(f"db.migrations.{name}")
+                run(migration_module.__file__, migration_module.up, migration_module.down, direction="up")
+        else:
+            if len(applied_migrations) == 0:
+                print("No applied migrations to roll back")
+                return
+
+            latest_migration = max(applied_migrations)
+            migration_module = import_module(f"db.migrations.{latest_migration}")
+            run(migration_module.__file__, migration_module.up, migration_module.down, direction="down")
+
 
 
 if __name__ == "__main__":

--- a/db/migrations/000_initial_schema.sql
+++ b/db/migrations/000_initial_schema.sql
@@ -15,9 +15,6 @@ CREATE TABLE IF NOT EXISTS Study (
     studyURL VARCHAR(100) DEFAULT NULL,
     studyUniqueID VARCHAR(100) DEFAULT NULL,
     PRIMARY KEY (studyId),
-
-    -- TODO: this should not be unique and it should definitely not be unique
-    -- only on the first 255 characters
     UNIQUE (studyDescription(255))
 );
 
@@ -50,10 +47,7 @@ CREATE TABLE IF NOT EXISTS Compartments (
     initialTemperature FLOAT(7,2) DEFAULT 0,
     carbonSource BOOLEAN DEFAULT FALSE,
     mediaNames VARCHAR(100) NOT NULL,
-
-    -- TODO: this should be nullable:
     mediaLink VARCHAR(100) NOT NULL,
-
     FOREIGN KEY (studyId) REFERENCES Study (studyId) ON UPDATE CASCADE ON DELETE CASCADE
 );
 
@@ -141,10 +135,7 @@ CREATE TABLE IF NOT EXISTS BioReplicatesMetadata (
     bioreplicateId VARCHAR(100),
     biosampleLink TEXT,
     bioreplicateDescrition TEXT,
-
-    -- TODO: This can't be unique
     PRIMARY KEY (bioreplicateId),
-
     UNIQUE (studyId, bioreplicateUniqueId),
     FOREIGN KEY (bioreplicateUniqueId) REFERENCES BioReplicatesPerExperiment (bioreplicateUniqueId)  ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (studyId) REFERENCES Study (studyId)  ON UPDATE CASCADE ON DELETE CASCADE
@@ -175,18 +166,13 @@ CREATE TABLE IF NOT EXISTS Perturbation (
 CREATE TABLE IF NOT EXISTS MetabolitePerExperiment (
     studyId VARCHAR(100),
     experimentUniqueId INT,
-
-    -- TODO Synthetic_Human_Gut_2 too long (encoding issue?)
     experimentId VARCHAR(100) NOT NULL,
-
     bioreplicateUniqueId INT,
     bioreplicateId VARCHAR(100),
     metabo_name VARCHAR(255) DEFAULT NULL,
     cheb_id VARCHAR(255),
 
-    -- TODO: this can't be primary key, the experiment id is not unique
     PRIMARY KEY (experimentId, bioreplicateId, cheb_id),
-
     FOREIGN KEY (cheb_id) REFERENCES Metabolites(cheb_id) ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (experimentUniqueId) REFERENCES Experiments(experimentUniqueId) ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (studyId) REFERENCES Study (studyId) ON UPDATE CASCADE ON DELETE CASCADE

--- a/db/migrations/2025_02_13_114748_increase_experiment_id_size.py
+++ b/db/migrations/2025_02_13_114748_increase_experiment_id_size.py
@@ -1,0 +1,24 @@
+import sqlalchemy as sql
+
+
+def up(conn):
+    query = """
+        ALTER TABLE Experiments
+        MODIFY COLUMN experimentId
+        VARCHAR(100);
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE Experiments
+        MODIFY COLUMN experimentId
+        VARCHAR(20);
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from lib.migrate import run
+    run(__file__, up, down)

--- a/db/migrations/2025_02_13_120609_rename_comunity_to_community.py
+++ b/db/migrations/2025_02_13_120609_rename_comunity_to_community.py
@@ -1,0 +1,47 @@
+import sqlalchemy as sql
+
+
+def up(conn):
+    query = """
+        ALTER TABLE CompartmentsPerExperiment
+        CHANGE comunityId communityId VARCHAR(100) NOT NULL
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE CompartmentsPerExperiment
+        CHANGE comunityUniqueId communityUniqueId INT
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE Community
+        CHANGE comunityId communityId VARCHAR(100) NOT NULL
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE Community
+        CHANGE communityId comunityId VARCHAR(100) NOT NULL
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE CompartmentsPerExperiment
+        CHANGE communityUniqueId comunityUniqueId INT
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE CompartmentsPerExperiment
+        CHANGE communityId comunityId VARCHAR(100) NOT NULL
+    """
+    conn.execute(sql.text(query))
+
+
+
+if __name__ == "__main__":
+    from lib.migrate import run
+    run(__file__, up, down)

--- a/db/migrations/2025_02_13_121409_rename_comunity_to_community_2.py
+++ b/db/migrations/2025_02_13_121409_rename_comunity_to_community_2.py
@@ -1,0 +1,34 @@
+import sqlalchemy as sql
+
+
+def up(conn):
+    query = """
+        ALTER TABLE Community
+        CHANGE comunityUniqueId communityUniqueId INT NOT NULL AUTO_INCREMENT
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE Community
+        RENAME KEY comunityId TO communityId
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE Community
+        RENAME KEY communityId TO comunityId
+    """
+    conn.execute(sql.text(query))
+
+    query = """
+        ALTER TABLE Community
+        CHANGE communityUniqueId comunityUniqueId INT NOT NULL AUTO_INCREMENT
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from lib.migrate import run
+    run(__file__, up, down)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -177,7 +177,7 @@ DROP TABLE IF EXISTS Experiments;
 CREATE TABLE Experiments (
   studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
   experimentUniqueId int NOT NULL AUTO_INCREMENT,
-  experimentId varchar(20) COLLATE utf8mb4_bin DEFAULT NULL,
+  experimentId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
   experimentDescription text COLLATE utf8mb4_bin,
   cultivationMode varchar(50) COLLATE utf8mb4_bin DEFAULT NULL,
   controlDescription text COLLATE utf8mb4_bin,
@@ -398,6 +398,6 @@ CREATE TABLE TechniquesPerExperiment (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-INSERT INTO MigrationVersions VALUES (1,'2024_11_11_160324_initial_schema','2025-02-05 11:02:45'),(2,'2024_11_11_164726_remove_unique_study_description_index','2025-02-05 11:02:46'),(3,'2024_11_21_115349_allow_null_medialink','2025-02-05 11:02:46'),(4,'2024_11_21_120444_fix_unique_primary_keys','2025-02-05 11:02:46'),(5,'2025_01_30_152951_fix_bioreplicates_metadata_unique_id','2025-02-05 11:02:46'),(6,'2025_02_04_134239_rename-chebi-id','2025-02-05 11:02:46'),(8,'2025_02_05_134203_make-project-and-study-uuids-unique','2025-02-05 13:46:32'),(10,'2025_02_12_170210_add-assembly-id-to-strains','2025-02-12 17:04:45');
+INSERT INTO MigrationVersions VALUES (1,'2024_11_11_160324_initial_schema','2025-02-05 11:02:45'),(2,'2024_11_11_164726_remove_unique_study_description_index','2025-02-05 11:02:46'),(3,'2024_11_21_115349_allow_null_medialink','2025-02-05 11:02:46'),(4,'2024_11_21_120444_fix_unique_primary_keys','2025-02-05 11:02:46'),(5,'2025_01_30_152951_fix_bioreplicates_metadata_unique_id','2025-02-05 11:02:46'),(6,'2025_02_04_134239_rename-chebi-id','2025-02-05 11:02:46'),(8,'2025_02_05_134203_make-project-and-study-uuids-unique','2025-02-05 13:46:32'),(10,'2025_02_12_170210_add-assembly-id-to-strains','2025-02-12 17:04:45'),(12,'2025_02_13_114748_increase_experiment_id_size','2025-02-13 12:00:02');
 
--- Dump completed on 2025-02-12 17:04:45
+-- Dump completed on 2025-02-13 12:00:02

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -97,11 +97,11 @@ DROP TABLE IF EXISTS Community;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE Community (
   studyId varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
-  comunityUniqueId int NOT NULL AUTO_INCREMENT,
-  comunityId varchar(50) COLLATE utf8mb4_bin NOT NULL,
+  communityUniqueId int NOT NULL AUTO_INCREMENT,
+  communityId varchar(100) COLLATE utf8mb4_bin NOT NULL,
   strainId int DEFAULT NULL,
-  PRIMARY KEY (comunityUniqueId),
-  UNIQUE KEY comunityId (comunityId,strainId),
+  PRIMARY KEY (communityUniqueId),
+  UNIQUE KEY communityId (communityId,strainId),
   KEY fk_1 (strainId),
   KEY fk_2 (studyId),
   CONSTRAINT Community_fk_1 FOREIGN KEY (strainId) REFERENCES Strains (strainId) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -154,15 +154,15 @@ CREATE TABLE CompartmentsPerExperiment (
   experimentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
   compartmentUniqueId int NOT NULL,
   compartmentId varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  comunityUniqueId int NOT NULL,
-  comunityId varchar(100) COLLATE utf8mb4_bin NOT NULL,
-  PRIMARY KEY (experimentUniqueId,compartmentUniqueId,comunityUniqueId),
+  communityUniqueId int NOT NULL,
+  communityId varchar(100) COLLATE utf8mb4_bin NOT NULL,
+  PRIMARY KEY (experimentUniqueId,compartmentUniqueId,communityUniqueId),
   KEY fk_2 (compartmentUniqueId),
-  KEY fk_3 (comunityUniqueId),
+  KEY fk_3 (communityUniqueId),
   KEY fk_4 (studyId),
   CONSTRAINT CompartmentsPerExperiment_fk_1 FOREIGN KEY (experimentUniqueId) REFERENCES Experiments (experimentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT CompartmentsPerExperiment_fk_2 FOREIGN KEY (compartmentUniqueId) REFERENCES Compartments (compartmentUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT CompartmentsPerExperiment_fk_3 FOREIGN KEY (comunityUniqueId) REFERENCES Community (comunityUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT CompartmentsPerExperiment_fk_3 FOREIGN KEY (communityUniqueId) REFERENCES Community (communityUniqueId) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT CompartmentsPerExperiment_fk_4 FOREIGN KEY (studyId) REFERENCES Study (studyId) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -398,6 +398,6 @@ CREATE TABLE TechniquesPerExperiment (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
-INSERT INTO MigrationVersions VALUES (1,'2024_11_11_160324_initial_schema','2025-02-05 11:02:45'),(2,'2024_11_11_164726_remove_unique_study_description_index','2025-02-05 11:02:46'),(3,'2024_11_21_115349_allow_null_medialink','2025-02-05 11:02:46'),(4,'2024_11_21_120444_fix_unique_primary_keys','2025-02-05 11:02:46'),(5,'2025_01_30_152951_fix_bioreplicates_metadata_unique_id','2025-02-05 11:02:46'),(6,'2025_02_04_134239_rename-chebi-id','2025-02-05 11:02:46'),(8,'2025_02_05_134203_make-project-and-study-uuids-unique','2025-02-05 13:46:32'),(10,'2025_02_12_170210_add-assembly-id-to-strains','2025-02-12 17:04:45'),(12,'2025_02_13_114748_increase_experiment_id_size','2025-02-13 12:00:02');
+INSERT INTO MigrationVersions VALUES (1,'2024_11_11_160324_initial_schema','2025-02-05 11:02:45'),(2,'2024_11_11_164726_remove_unique_study_description_index','2025-02-05 11:02:46'),(3,'2024_11_21_115349_allow_null_medialink','2025-02-05 11:02:46'),(4,'2024_11_21_120444_fix_unique_primary_keys','2025-02-05 11:02:46'),(5,'2025_01_30_152951_fix_bioreplicates_metadata_unique_id','2025-02-05 11:02:46'),(6,'2025_02_04_134239_rename-chebi-id','2025-02-05 11:02:46'),(8,'2025_02_05_134203_make-project-and-study-uuids-unique','2025-02-05 13:46:32'),(10,'2025_02_12_170210_add-assembly-id-to-strains','2025-02-12 17:04:45'),(14,'2025_02_13_114748_increase_experiment_id_size','2025-02-13 12:10:07'),(16,'2025_02_13_120609_rename_comunity_to_community','2025-02-13 12:13:22'),(19,'2025_02_13_121409_rename_comunity_to_community_2','2025-02-13 12:16:22');
 
--- Dump completed on 2025-02-13 12:00:02
+-- Dump completed on 2025-02-13 12:16:22

--- a/legacy/populate_db.py
+++ b/legacy/populate_db.py
@@ -244,7 +244,7 @@ def save_submission_to_database(conn, yml_dir, submission, data_template):
                         errors_logic.append(error_ms)
                     comunities = {
                         'studyId': study_id,
-                        'comunityId': info_comu['Community_ID'][i],
+                        'communityId': info_comu['Community_ID'][i],
                         'strainId': strain_id
                     }
                     comunities_filtered = {k: v for k, v in comunities.items() if v is not None}
@@ -299,7 +299,6 @@ def save_submission_to_database(conn, yml_dir, submission, data_template):
                 comp_biorep = stripping_method(info_experiments['Compartment_ID'][i])
                 comu_biorep = stripping_method(info_experiments['Community_ID'][i])
 
-                # TODO: rename comunity -> community
                 # TODO Impossible to add a blank community, since there is one entry in "Community" for each member
 
                 for j,k in zip(comp_biorep, itertools.cycle(comu_biorep)):
@@ -314,8 +313,8 @@ def save_submission_to_database(conn, yml_dir, submission, data_template):
                         'experimentId': info_experiments['Experiment_ID'][i],
                         'compartmentUniqueId': search_id(j, compartments_id_list),
                         'compartmentId': j,
-                        'comunityUniqueId': community_unique_id,
-                        'comunityId': k
+                        'communityUniqueId': community_unique_id,
+                        'communityId': k
                     }
                     comp_per_biorep_filtered = {t: v for t, v in comp_per_biorep.items() if v is not None}
                     if len(comp_per_biorep_filtered)>0:

--- a/lib/migrate.py
+++ b/lib/migrate.py
@@ -8,18 +8,20 @@ import sqlalchemy as sql
 from db import get_connection, get_config
 
 
-def run(file, up, down):
+def run(file, up, down, direction=None):
     """
     Run a migration
 
     Inputs
     ------
-    file:
-
-
+    file:      The filename of the migration, will be stored in the database after running
+    up:        The function to execute to apply the migration
+    down:      The function that reverts the migration
+    direction: "up" or "down", taken from command-line arguments if not provided, defaults to "up"
     """
     migration_name = Path(file).stem
-    direction = sys.argv[1] if len(sys.argv) > 1 else "up"
+    if direction is None:
+        direction = sys.argv[1] if len(sys.argv) > 1 else "up"
 
     with get_connection() as conn:
         migrated_at = conn.execute(

--- a/models/study_dfs.py
+++ b/models/study_dfs.py
@@ -104,8 +104,6 @@ def dynamical_query(all_advance_query):
 def get_general_info(studyId, conn):
     params = {'studyId': studyId}
 
-    # TODO (2025-02-03) There are multiple studies connected to multiple projects. The project unique id is not actually unique
-
     query = """
         SELECT studyId, studyName, studyDescription, studyURL, projectId
         FROM Study
@@ -153,7 +151,7 @@ def get_experiments(studyId, conn):
         GROUP_CONCAT(DISTINCT BRI.bioreplicateId) AS bioreplicateIds,
         E.controlDescription,
         GROUP_CONCAT(DISTINCT BR.bioreplicateId) AS control_bioreplicateIds,
-        GROUP_CONCAT(DISTINCT C.comunityId) AS comunityIds,
+        GROUP_CONCAT(DISTINCT C.communityId) AS communityIds,
         GROUP_CONCAT(DISTINCT CP.compartmentId) AS compartmentIds
     FROM
         Experiments AS E
@@ -193,7 +191,7 @@ def get_compartments(studyId, conn):
 def get_communities(studyId, conn):
     query = """
     SELECT
-        C.comunityId,
+        C.communityId,
         GROUP_CONCAT(DISTINCT S.memberName) AS memberNames,
         GROUP_CONCAT(DISTINCT CP.compartmentId) AS compartmentIds
     FROM
@@ -201,11 +199,11 @@ def get_communities(studyId, conn):
     LEFT JOIN
         Strains AS S ON C.strainId = S.strainId
     LEFT JOIN
-        CompartmentsPerExperiment AS CP ON CP.comunityUniqueId = C.comunityUniqueId
+        CompartmentsPerExperiment AS CP ON CP.communityUniqueId = C.communityUniqueId
     WHERE
         C.studyId = %(studyId)s
     GROUP BY
-        C.comunityId;
+        C.communityId;
     """
     df_communities = pd.read_sql(query, conn, params={'studyId': studyId})
     return df_communities

--- a/streamlit/src/db_functions.py
+++ b/streamlit/src/db_functions.py
@@ -313,7 +313,7 @@ def getExperiments(studyID, conn):
         GROUP_CONCAT(DISTINCT BRI.bioreplicateId) AS bioreplicateIds,
         E.controlDescription,
         GROUP_CONCAT(DISTINCT BR.bioreplicateId) AS control_bioreplicateIds,
-        GROUP_CONCAT(DISTINCT C.comunityId) AS comunityIds,
+        GROUP_CONCAT(DISTINCT C.communityId) AS communityIds,
         GROUP_CONCAT(DISTINCT CP.compartmentId) AS compartmentIds
     FROM
         Experiments AS E
@@ -366,7 +366,7 @@ def getPerturbations(studyID, conn):
 def getCommunities(studyID, conn):
     query = f"""
     SELECT
-        C.comunityId,
+        C.communityId,
         GROUP_CONCAT(DISTINCT S.memberName) AS memberNames,
         GROUP_CONCAT(DISTINCT CP.compartmentId) AS compartmentIds
     FROM
@@ -374,11 +374,11 @@ def getCommunities(studyID, conn):
     LEFT JOIN
         Strains AS S ON C.strainId = S.strainId
     LEFT JOIN
-        CompartmentsPerExperiment AS CP ON CP.comunityUniqueId = C.comunityUniqueId
+        CompartmentsPerExperiment AS CP ON CP.communityUniqueId = C.communityUniqueId
     WHERE
         C.studyId = '{studyID}'
     GROUP BY
-        C.comunityId;
+        C.communityId;
     """
     df_communities = conn.query(query, ttl=600)
     #columns_to_exclude = ['studyId', 'perturbationUniqueId']

--- a/streamlit/src/populate_db_mod.py
+++ b/streamlit/src/populate_db_mod.py
@@ -246,7 +246,7 @@ def populate_db(list_growth, list_metabolites, list_microbial_strains,raw_data_t
                         sys.exit()
                     comunities = {
                         'studyId': study_id,
-                        'comunityId': info_comu['Community_ID'][i],
+                        'communityId': info_comu['Community_ID'][i],
                         'strainId': strain_id
                     }
                     comunities_filtered = {k: v for k, v in comunities.items() if v is not None}
@@ -323,8 +323,8 @@ def populate_db(list_growth, list_metabolites, list_microbial_strains,raw_data_t
                         'experimentId': info['Experiment_ID'][i],
                         'compartmentUniqueId': search_id(j, compartments_id_list),
                         'compartmentId': j,
-                        'comunityUniqueId': search_id(k,comu_id_list),
-                        'comunityId': k
+                        'communityUniqueId': search_id(k,comu_id_list),
+                        'communityId': k
                     }
                     comp_per_biorep_filtered = {t: v for t, v in comp_per_biorep.items() if v is not None}
                     if len(comp_per_biorep_filtered)>0:


### PR DESCRIPTION
- Cleanup of finished TODOs
- Allow running migrations backwards one at a time ("rollback") by running `bin/migrations-run down`
- Fix the typo of "comunity" to "community" in the database and in the codebase
- Fix the length of the experiment id (which is really the name): it was only 20 in the Experiment table, but 100 in all the foreign keys.