### PR TITLE
API metadata additions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 # Controls when the workflow will run
 on:
   push:
-    branches: ["documentation-updates"]
+    branches: ["main", "api-metadata-additions"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -111,6 +111,7 @@ def experiment_json(publicId):
                 'id':                  b.id,
                 'name':                b.name,
                 'biosampleUrl':        b.biosampleUrl,
+                'isAverage':           b.calculationType == 'average',
                 'measurementContexts': [
                     {
                         'id': mc.id,
@@ -185,6 +186,7 @@ def bioreplicate_json(id):
         'studyId':              bioreplicate.experiment.studyId,
         'name':                 bioreplicate.name,
         'biosampleUrl':         bioreplicate.biosampleUrl,
+        'isAverage':            bioreplicate.calculationType == 'average',
         'measurementTimeUnits': 'h',
         'measurementContexts': [
             {

--- a/docs/api.md
+++ b/docs/api.md
@@ -314,6 +314,7 @@ Output structure (note that compartment values encoded as decimal numbers are re
     id: number,
     name: string
     biosampleUrl?: string,
+    isAverage: boolean,
     measurementContexts: [{
       id: number,
       experimentId: "EMGDBxxx",
@@ -397,6 +398,7 @@ Example output:
       "id": 60111,
       "name": "Average(BT_MUCIN)",
       "biosampleUrl": null,
+      "isAverage": true,
       "measurementContexts": [
         {
           "id": 1431,
@@ -558,11 +560,12 @@ Output structure:
 
 ```typescript
 {
-  id: 60332,
-  experimentId: "EMGDB000000023",
-  studyId: "SMGDB00000002",
-  name: "Average(BTRI_MUCIN)",
+  id: number,
+  experimentId: "EMGDBxxx",
+  studyId: "SMGDBxxx",
+  name: string,
   biosampleUrl: null,
+  isAverage: boolean,
   measurementTimeUnits: "h",
   measurementContexts: [{
     id: number,
@@ -592,6 +595,7 @@ curl -s "$ROOT_URL/api/v1/bioreplicate/1314.csv"
   "studyId": "SMGDB00000002",
   "name": "Average(BTRI_MUCIN)",
   "biosampleUrl": null,
+  "isAverage": true,
   "measurementTimeUnits": "h",
   "measurementContexts": [
     {


### PR DESCRIPTION
For now, a minor addition, rendering whether a particular bioreplicate is the "average" one. I may update this branch with more extras as I experiment with the data loader at https://gitlab.com/ComputationalScience/mugrowthctrl
