### PR TITLE
Push model predictions through api

### DIFF
--- a/app/model/orm/modeling_result.py
+++ b/app/model/orm/modeling_result.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime
 from decimal import Decimal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -94,7 +95,12 @@ class ModelingResult(OrmBase):
 
     params: Mapped[sql.JSON] = mapped_column(sql.JSON, nullable=False)
 
-    state:    Mapped[str] = mapped_column(sql.String(100), default='pending')
+    state: Mapped[Literal[
+        'pending',
+        'ready',
+        'error',
+    ]] = mapped_column(sql.String(100), default='pending')
+
     error:    Mapped[str] = mapped_column(sql.String)
     rSummary: Mapped[str] = mapped_column(sql.String)
 

--- a/app/model/orm/study.py
+++ b/app/model/orm/study.py
@@ -151,6 +151,8 @@ class Study(OrmBase):
             return False
         elif user.isAdmin:
             return True
+        elif user.uuid == self.ownerUuid:
+            return True
         else:
             return user.uuid in self.managerUuids
 

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -750,7 +750,10 @@ def _find_or_create_custom_model(study_id, model_data):
             url=model_data.get('url'),
             description=model_data.get('description'),
         )
-        g.db_session.add(custom_model)
-        g.db_session.flush()
+    else:
+        custom_model.update(**model_data)
+
+    g.db_session.add(custom_model)
+    g.db_session.flush()
 
     return custom_model

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -1,5 +1,6 @@
 import re
 import json
+from datetime import datetime, UTC
 from io import StringIO
 
 from flask import (
@@ -244,7 +245,8 @@ def measurement_context_update_model_predictions(id):
         customModelId=custom_model.id,
         xValues=df[df.columns[0]].tolist(),
         yValues=df[df.columns[1]].tolist(),
-        yErrors=([] if len(df.columns) < 3 else df[df.columns[3]].tolist())
+        yErrors=([] if len(df.columns) < 3 else df[df.columns[3]].tolist()),
+        publishedAt=datetime.now(UTC),
     )
     g.db_session.add(modeling_result)
     g.db_session.commit()

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -258,6 +258,18 @@ def model_prediction_json(id):
     if not modeling_result or not modeling_result.study.visible_to_user(current_user):
         raise NotFound
 
+    if modeling_result.customModelId is None:
+        custom_model_fields = {}
+    else:
+        custom_model_fields = {
+            'customModel': {
+                'name':        modeling_result.customModel.name,
+                'shortName':   modeling_result.customModel.shortName,
+                'url':         modeling_result.customModel.url,
+                'description': modeling_result.customModel.description,
+            }
+        }
+
     return {
         'id':                   modeling_result.id,
         'measurementContextId': modeling_result.measurementContextId,
@@ -265,6 +277,7 @@ def model_prediction_json(id):
         'type':                 modeling_result.type,
         'params':               modeling_result.params,
         'calculatedAt':         modeling_result.calculatedAt,
+        **custom_model_fields,
     }
 
 

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -162,32 +162,7 @@ def experiment_modeling_update_json(publicId):
     if not experiment.study.manageable_by_user(current_user):
         raise Forbidden
 
-    if 'model' not in request_json:
-        raise BadRequest("Missing 'model' data to create the records under")
-    if 'name' not in request_json['model']:
-        raise BadRequest("Missing 'name' key in the 'model' data to create the records under")
-
-    if 'shortName' in request_json['model'] and len(request_json['model']['shortName']) > 5:
-        short_name = request_json['model']['shortName']
-        raise BadRequest(f"Given 'shortName' ({short_name}) is too long for a model (maximum 5 characters)")
-
-    custom_model = g.db_session.scalars(
-        sql.select(CustomModel)
-        .where(
-            CustomModel.studyId == experiment.studyId,
-            CustomModel.name == request_json['model']['name'],
-        )
-    ).one_or_none()
-    if not custom_model:
-        custom_model = CustomModel(
-            studyId=experiment.studyId,
-            name=request_json['model']['name'],
-            shortName=request_json['model'].get('shortName'),
-            url=request_json['model'].get('url'),
-            description=request_json['model'].get('description'),
-        )
-        g.db_session.add(custom_model)
-        g.db_session.flush()
+    custom_model = _find_or_create_custom_model(experiment.studyId, request_json)
 
     # TODO: clear out existing, how? Add `sourceType` to model records
     # Clear out existing "api" entries, unless we got an `append` parameter:
@@ -283,6 +258,56 @@ def measurement_context_csv(id):
         df.rename(columns={'value': plain_label}, inplace=True)
 
     return df.to_csv(index=False)
+
+
+def measurement_context_update_model_predictions(id):
+    request_json = json.loads(request.data)
+    current_user = _get_current_user(request_json.get('apiKey'))
+
+    measurement_context = g.db_session.get(MeasurementContext, id)
+    if not measurement_context:
+        raise NotFound
+    if not measurement_context.study.manageable_by_user(current_user):
+        raise Forbidden
+
+    if 'data' not in request_json:
+        raise BadRequest("No 'data' given in CSV format")
+
+    custom_model = _find_or_create_custom_model(measurement_context.study.publicId, request_json.get('model'))
+
+    existing_modeling_results = g.db_session.scalars(
+        sql.select(ModelingResult)
+        .where(
+            ModelingResult.measurementContextId == measurement_context.id,
+            ModelingResult.customModelId == custom_model.id,
+        )
+    ).all()
+    for modeling_result in existing_modeling_results:
+        g.db_session.delete(modeling_result)
+
+    df = pd.read_csv(StringIO(request_json['data']))
+
+    # Check for enough rows and columns:
+    if len(df.columns) < 2:
+        raise BadRequest(f"At least 2 columns are expected, {len(df.columns)} were found")
+
+    row_count = df.shape[0]
+    if row_count <= 0:
+        raise BadRequest("No data rows were found")
+
+    modeling_result = ModelingResult(
+        measurementContext=measurement_context,
+        type=f"custom_{custom_model.id}",
+        state='ready',
+        customModelId=custom_model.id,
+        xValues=df[df.columns[0]].tolist(),
+        yValues=df[df.columns[1]].tolist(),
+        yErrors=([] if len(df.columns) < 3 else df[df.columns[3]].tolist())
+    )
+    g.db_session.add(modeling_result)
+    g.db_session.commit()
+
+    return {'modelingResultId': modeling_result.id}
 
 
 def model_prediction_json(id):
@@ -699,3 +724,36 @@ def _convert_to_requested_units(df, source_units, metabolite_mass=None):
             raise ClientError(f"Unexpected metabolite count units requested: {target_units}")
 
         convert_df_units(df, source_units, target_units, metabolite_mass)
+
+
+def _find_or_create_custom_model(study_id, model_data):
+    if model_data is None:
+        raise BadRequest("Missing 'model' data to create the records under")
+
+    if 'name' not in model_data:
+        raise BadRequest("Missing 'name' key in the 'model' data to create the records under")
+
+    if 'shortName' in model_data and len(model_data['shortName']) > 5:
+        short_name = model_data['shortName']
+        raise BadRequest(f"Given 'shortName' ({short_name}) is too long for a model (maximum 5 characters)")
+
+    custom_model = g.db_session.scalars(
+        sql.select(CustomModel)
+        .where(
+            CustomModel.studyId == study_id,
+            CustomModel.name == model_data['name'],
+        )
+    ).one_or_none()
+
+    if not custom_model:
+        custom_model = CustomModel(
+            studyId=study_id,
+            name=model_data['name'],
+            shortName=model_data.get('shortName'),
+            url=model_data.get('url'),
+            description=model_data.get('description'),
+        )
+        g.db_session.add(custom_model)
+        g.db_session.flush()
+
+    return custom_model

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -229,6 +229,9 @@ def measurement_context_update_model_predictions(id):
         g.db_session.delete(modeling_result)
 
     df = pd.read_csv(StringIO(request_json['data']))
+    if prediction_units := request_json.get('units'):
+        metabolite_mass = _get_metabolite_mass(measurement_context)
+        result = convert_df_units(df, prediction_units, measurement_context.units, metabolite_mass)
 
     # Check for enough rows and columns:
     if len(df.columns) < 2:

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -257,6 +257,43 @@ def measurement_context_update_model_predictions(id):
     return {'modelingResultId': modeling_result.id}
 
 
+def measurement_context_delete_model_predictions(id):
+    request_json = json.loads(request.data)
+    current_user = _get_current_user(request_json.get('apiKey'))
+
+    measurement_context = g.db_session.get(MeasurementContext, id)
+    if not measurement_context:
+        raise NotFound
+    if not measurement_context.study.manageable_by_user(current_user):
+        raise Forbidden
+
+    if 'modelName' not in request_json:
+        raise BadRequest("No 'modelName' given to delete the data of")
+
+    custom_model = g.db_session.scalars(
+        sql.select(CustomModel)
+        .where(
+            CustomModel.studyId == measurement_context.study.publicId,
+            CustomModel.name == request_json['modelName']
+        )
+    ).one()
+
+    modeling_results = g.db_session.scalars(
+        sql.select(ModelingResult)
+        .where(
+            ModelingResult.measurementContextId == measurement_context.id,
+            ModelingResult.customModelId == custom_model.id,
+        )
+    ).all()
+
+    for modeling_result in modeling_results:
+        g.db_session.delete(modeling_result)
+
+    g.db_session.commit()
+
+    return {'status': 'ok'}
+
+
 def model_prediction_json(id):
     current_user = _get_current_user()
     modeling_result = g.db_session.get(ModelingResult, id)

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -145,64 +145,6 @@ def experiment_json(publicId):
     }
 
 
-def experiment_modeling_update_json(publicId):
-    if not request.data:
-        raise BadRequest("No JSON data payload")
-
-    request_json = json.loads(request.data)
-
-    if 'entries' not in request_json:
-        raise BadRequest("No 'entries' array given")
-
-    current_user = _get_current_user(request_json.get('apiKey'))
-    if current_user is None:
-        raise Forbidden
-
-    experiment = g.db_session.get(Experiment, publicId)
-    if not experiment.study.manageable_by_user(current_user):
-        raise Forbidden
-
-    custom_model = _find_or_create_custom_model(experiment.studyId, request_json)
-
-    # TODO: clear out existing, how? Add `sourceType` to model records
-    # Clear out existing "api" entries, unless we got an `append` parameter:
-    # for entry in workspace.entries:
-    #     if entry.sourceType == 'api':
-    #         g.db_session.delete(entry)
-
-    # Create "api" entries
-    modeling_results = []
-    for entry in request_json['entries']:
-        df = pd.read_csv(StringIO(entry['data']))
-
-        # Check for enough rows and columns:
-        if len(df.columns) < 2:
-            raise BadRequest(f"At least 2 columns are expected, {len(df.columns)} were found")
-
-        row_count = df.shape[0]
-        if row_count <= 0:
-            raise BadRequest("No data rows were found")
-
-        # If label is not provided, use second column's name
-        label = entry.get('label') or df.columns[1]
-
-        modeling_results.append(ModelingResult(
-            type=f"custom_{custom_model.id}",
-            customModelId=custom_model.id,
-            xValues=df[df.columns[0]].tolist(),
-            yValues=df[df.columns[1]].tolist(),
-            yErrors=([] if len(df.columns) < 3 else df[df.columns[3]].tolist())
-        ))
-
-    g.db_session.add_all(modeling_results)
-    g.db_session.commit()
-
-    return {
-        'status': 'ok',
-        'customModelId': custom_model.id,
-    }
-
-
 def experiment_csv(publicId):
     current_user = _get_current_user()
     experiment = g.db_session.get(Experiment, publicId)

--- a/app/pages/api.py
+++ b/app/pages/api.py
@@ -20,6 +20,7 @@ from app.model.lib.conversion import (
 )
 from app.model.orm import (
     Bioreplicate,
+    CustomModel,
     Experiment,
     Measurement,
     MeasurementContext,
@@ -141,6 +142,89 @@ def experiment_json(publicId):
             }
             for b in experiment.bioreplicates
         ]
+    }
+
+
+def experiment_modeling_update_json(publicId):
+    if not request.data:
+        raise BadRequest("No JSON data payload")
+
+    request_json = json.loads(request.data)
+
+    if 'entries' not in request_json:
+        raise BadRequest("No 'entries' array given")
+
+    current_user = _get_current_user(request_json.get('apiKey'))
+    if current_user is None:
+        raise Forbidden
+
+    experiment = g.db_session.get(Experiment, publicId)
+    if not experiment.study.manageable_by_user(current_user):
+        raise Forbidden
+
+    if 'model' not in request_json:
+        raise BadRequest("Missing 'model' data to create the records under")
+    if 'name' not in request_json['model']:
+        raise BadRequest("Missing 'name' key in the 'model' data to create the records under")
+
+    if 'shortName' in request_json['model'] and len(request_json['model']['shortName']) > 5:
+        short_name = request_json['model']['shortName']
+        raise BadRequest(f"Given 'shortName' ({short_name}) is too long for a model (maximum 5 characters)")
+
+    custom_model = g.db_session.scalars(
+        sql.select(CustomModel)
+        .where(
+            CustomModel.studyId == experiment.studyId,
+            CustomModel.name == request_json['model']['name'],
+        )
+    ).one_or_none()
+    if not custom_model:
+        custom_model = CustomModel(
+            studyId=experiment.studyId,
+            name=request_json['model']['name'],
+            shortName=request_json['model'].get('shortName'),
+            url=request_json['model'].get('url'),
+            description=request_json['model'].get('description'),
+        )
+        g.db_session.add(custom_model)
+        g.db_session.flush()
+
+    # TODO: clear out existing, how? Add `sourceType` to model records
+    # Clear out existing "api" entries, unless we got an `append` parameter:
+    # for entry in workspace.entries:
+    #     if entry.sourceType == 'api':
+    #         g.db_session.delete(entry)
+
+    # Create "api" entries
+    modeling_results = []
+    for entry in request_json['entries']:
+        df = pd.read_csv(StringIO(entry['data']))
+
+        # Check for enough rows and columns:
+        if len(df.columns) < 2:
+            raise BadRequest(f"At least 2 columns are expected, {len(df.columns)} were found")
+
+        row_count = df.shape[0]
+        if row_count <= 0:
+            raise BadRequest("No data rows were found")
+
+        # If label is not provided, use second column's name
+        label = entry.get('label') or df.columns[1]
+
+        modeling_results.append(ModelingResult(
+            type=f"custom_{custom_model.id}",
+            customModelId=custom_model.id,
+            xValues=df[df.columns[0]].tolist(),
+            yValues=df[df.columns[1]].tolist(),
+            yErrors=([] if len(df.columns) < 3 else df[df.columns[3]].tolist())
+        ))
+
+    g.db_session.add_all(modeling_results)
+    g.db_session.commit()
+
+    return {
+        'status': 'ok',
+        'customModelId': custom_model.id,
     }
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,7 +72,7 @@ The data in mGrowthDB is publicly available, but in some cases, it may not be pu
 
 Workspaces allow more fine-grained access. You can provide an API key to get read and write access to workspaces that you own. You can find this key in your profile page and reset it if it becomes compromised.
 
-To pass the API key along to a request, you can attach it as the query parameter `apiKey`, or you can send it in a JSON payload. You can see examples of this in the "Workspaces" section.
+To pass the API key along to a request, you can attach it as the query parameter `apiKey`, or you can send it in a JSON payload. You can see examples of this in the "Workspaces" section. The API key can also be used to attach model predictions to measurement contexts that will be available for plotting on the web interface.
 
 ## Search
 
@@ -700,6 +700,8 @@ measurementContextId,subjectType,subjectName,subjectExternalId,time,value,std
 
 The database includes modeling functionality -- users can fit models in the application interface, or they can upload custom models. The modeling records will be returned when fetching measurement contexts in the `modelPredictionIds` key, which in the examples so far has been empty.
 
+### Fetching data
+
 If you have a model prediction id, you can fetch the JSON metadata that describes this fit and a CSV of its predictions from the `/model-prediction/` endpoint.
 
 Structure:
@@ -758,6 +760,36 @@ time,value,std
 1.809045226130653,7785.456559068567,
 [...196 more lines...]
 ```
+
+### Pushing data
+
+If you provide an API key, you can attach custom model predictions to individual measurement contexts from the API. This is similar to how you would use workspaces, described in the next section. Here is an example payload that can be sent to one of these endpoints:
+
+```json
+{
+  "apiKey": "[redacted]",
+  "units": "Cells/μL",
+  "data": "time,value,std\n0.0,2197.0,\n4.0,2105.0,\n8.0,2505.0,\n",
+  "model": {
+      "name": "My custom model",
+      "shortName": "MCM",
+      "url": "my-custom-model.example.com",
+      "description": "A custom model."
+  }
+}
+```
+
+Most of the model information is optional, only the "name" key is mandatory. To learn more about uploading data and defining a custom model, read the "Uploading custom model data" section in the "[Modeling interface](https://mgrowthdb.gbiomed.kuleuven.be/help/modeling-interface/)" section of the help files.
+
+We can save this file as `payload.json` and then trigger a curl request, passing it along like this:
+
+```bash
+curl -s "$ROOT_URL/api/v1/measurement-context/123/model-predictions.json" \
+    --header "Content-Type: application/json" \
+    --data @payload.json
+```
+
+The measurement context ID given in the example is arbitrary. Ideally, it's recommended to fetch data through the "experiment" endpoint, associate the data you're operating on with its measurement context ID, and then push predictions to the `model-predictions.json` endpoint. The response at this time only contains a `{'status': 'ok'}` payload if successful. In case of a validation error or missing required data, you should receive the appropriate HTTP status code and JSON describing the issue.
 
 ## Workspaces
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -791,6 +791,26 @@ curl -s "$ROOT_URL/api/v1/measurement-context/123/model-predictions.json" \
 
 The measurement context ID given in the example is arbitrary. Ideally, it's recommended to fetch data through the "experiment" endpoint, associate the data you're operating on with its measurement context ID, and then push predictions to the `model-predictions.json` endpoint. The response at this time only contains a `{'status': 'ok'}` payload if successful. In case of a validation error or missing required data, you should receive the appropriate HTTP status code and JSON describing the issue.
 
+To clear the model predictions for a particular custom model, we can send a `DELETE` request instead of a `POST` request. Example payload:
+
+```json
+{
+  "apiKey": "[redacted]",
+  "modelName": "My custom model"
+}
+```
+
+And example request:
+
+```bash
+curl -s "$ROOT_URL/api/v1/measurement-context/123/model-predictions.json" \
+    --request DELETE \
+    --header "Content-Type: application/json" \
+    --data @payload.json
+```
+
+Note that this is the same URL, but with a different `--request` flag that changes the HTTP method that is used to make the request.
+
 ## Workspaces
 
 A workspace is identified by two parameters:

--- a/initialization/global_handlers.py
+++ b/initialization/global_handlers.py
@@ -1,3 +1,4 @@
+import html
 from uuid import uuid4
 from datetime import datetime, UTC
 
@@ -145,6 +146,7 @@ def _render_bad_request(error):
     if _is_json(request):
         # Clean HTML-like description for JSON
         description = description.removeprefix('<p>').removesuffix('</p>')
+        description = html.unescape(description)
 
         return {'error': '400 Bad request', 'description': description}, 400
     else:

--- a/initialization/global_handlers.py
+++ b/initialization/global_handlers.py
@@ -169,7 +169,7 @@ def _render_forbidden(_error):
 
 def _render_client_error(error):
     if _is_json(request):
-        return {'error': str(error)}, 400
+        return {'error': '400 Bad request', 'description': str(error)}, 400
     if _is_csv(request):
         return str(error), 400
 

--- a/initialization/routes.py
+++ b/initialization/routes.py
@@ -246,6 +246,11 @@ def init_routes(app):
     app.add_url_rule("/api/v1/study/<string:publicId>.json",      view_func=api_pages.study_json)
     app.add_url_rule("/api/v1/experiment/<string:publicId>.json", view_func=api_pages.experiment_json)
     app.add_url_rule("/api/v1/experiment/<string:publicId>.csv",  view_func=api_pages.experiment_csv)
+    app.add_url_rule(
+        "/api/v1/experiment/<string:publicId>/modeling.json",
+        view_func=api_pages.experiment_modeling_update_json,
+        methods=["POST"],
+    )
 
     app.add_url_rule("/api/v1/measurement-context/<int:id>.json", view_func=api_pages.measurement_context_json)
     app.add_url_rule("/api/v1/measurement-context/<int:id>.csv",  view_func=api_pages.measurement_context_csv)

--- a/initialization/routes.py
+++ b/initialization/routes.py
@@ -246,17 +246,24 @@ def init_routes(app):
     app.add_url_rule("/api/v1/study/<string:publicId>.json",      view_func=api_pages.study_json)
     app.add_url_rule("/api/v1/experiment/<string:publicId>.json", view_func=api_pages.experiment_json)
     app.add_url_rule("/api/v1/experiment/<string:publicId>.csv",  view_func=api_pages.experiment_csv)
+
+    # TODO (2026-07-13) Remove
     app.add_url_rule(
         "/api/v1/experiment/<string:publicId>/modeling.json",
         view_func=api_pages.experiment_modeling_update_json,
         methods=["POST"],
     )
 
-    app.add_url_rule("/api/v1/measurement-context/<int:id>.json", view_func=api_pages.measurement_context_json)
-    app.add_url_rule("/api/v1/measurement-context/<int:id>.csv",  view_func=api_pages.measurement_context_csv)
-
     app.add_url_rule("/api/v1/bioreplicate/<int:id>.json", view_func=api_pages.bioreplicate_json)
     app.add_url_rule("/api/v1/bioreplicate/<int:id>.csv",  view_func=api_pages.bioreplicate_csv)
+
+    app.add_url_rule("/api/v1/measurement-context/<int:id>.json", view_func=api_pages.measurement_context_json)
+    app.add_url_rule("/api/v1/measurement-context/<int:id>.csv",  view_func=api_pages.measurement_context_csv)
+    app.add_url_rule(
+        "/api/v1/measurement-context/<int:id>/model-predictions.json",
+        view_func=api_pages.measurement_context_update_model_predictions,
+        methods=["POST"],
+    )
 
     app.add_url_rule("/api/v1/model-prediction/<int:id>.json", view_func=api_pages.model_prediction_json)
     app.add_url_rule("/api/v1/model-prediction/<int:id>.csv",  view_func=api_pages.model_prediction_csv)

--- a/initialization/routes.py
+++ b/initialization/routes.py
@@ -247,13 +247,6 @@ def init_routes(app):
     app.add_url_rule("/api/v1/experiment/<string:publicId>.json", view_func=api_pages.experiment_json)
     app.add_url_rule("/api/v1/experiment/<string:publicId>.csv",  view_func=api_pages.experiment_csv)
 
-    # TODO (2026-07-13) Remove
-    app.add_url_rule(
-        "/api/v1/experiment/<string:publicId>/modeling.json",
-        view_func=api_pages.experiment_modeling_update_json,
-        methods=["POST"],
-    )
-
     app.add_url_rule("/api/v1/bioreplicate/<int:id>.json", view_func=api_pages.bioreplicate_json)
     app.add_url_rule("/api/v1/bioreplicate/<int:id>.csv",  view_func=api_pages.bioreplicate_csv)
 

--- a/initialization/routes.py
+++ b/initialization/routes.py
@@ -257,6 +257,11 @@ def init_routes(app):
         view_func=api_pages.measurement_context_update_model_predictions,
         methods=["POST"],
     )
+    app.add_url_rule(
+        "/api/v1/measurement-context/<int:id>/model-predictions.json",
+        view_func=api_pages.measurement_context_delete_model_predictions,
+        methods=["DELETE"],
+    )
 
     app.add_url_rule("/api/v1/model-prediction/<int:id>.json", view_func=api_pages.model_prediction_json)
     app.add_url_rule("/api/v1/model-prediction/<int:id>.csv",  view_func=api_pages.model_prediction_csv)

--- a/tests/pages/test_api.py
+++ b/tests/pages/test_api.py
@@ -5,7 +5,7 @@ from datetime import datetime, UTC
 
 import sqlalchemy as sql
 
-from app.model.orm import WorkspaceEntry
+from app.model.orm import CustomModel, WorkspaceEntry
 from tests.page_test import PageTest
 
 
@@ -125,6 +125,56 @@ class TestApiPages(PageTest):
         response_json = self._get_json(response)
 
         self.assertEqual(response_json['error'], '404 Not found')
+
+
+    def test_updating_experiment(self):
+        user = self.create_user(apiKey='test1')
+
+        s1 = self.create_study(ownerUuid=user.uuid, publishedAt=datetime.now(UTC))
+        s2 = self.create_study(publishedAt=datetime.now(UTC))
+
+        e1 = self.create_experiment(studyId=s1.publicId)
+        e2 = self.create_experiment(studyId=s2.publicId)
+
+        self.db_session.commit()
+
+        payload = {
+            'apiKey': 'test1',
+            'model': {
+                'name': 'Test model',
+                'shortName': 'TM',
+                'description': 'Test model',
+            },
+            'entries': [{
+                'data': "time,value\n1,100\n2,200",
+            }]
+        }
+
+        # Study doesn't belong to this user, even if it's published
+        response = self.client.post(
+            f"/api/v1/experiment/{e2.publicId}/modeling.json",
+            data=json.dumps(payload),
+        )
+        response_json = self._get_json(response)
+        print(response_json)
+        self.assertEqual(response_json['error'], '403 Forbidden')
+
+        # Successful update:
+        response = self.client.post(
+            f"/api/v1/experiment/{e1.publicId}/modeling.json",
+            data=json.dumps(payload),
+        )
+        response_json = self._get_json(response)
+        self.assertEqual(response_json['status'], 'ok')
+
+        self.db_session.commit()
+
+        # Custom model exists now:
+        custom_model = self.db_session.get(CustomModel, response_json['customModelId'])
+        self.assertEqual(custom_model.study, s1)
+
+        # TODO (2026-07-09) Validate creation of modeling results
+
 
     def test_measurement_csv(self):
         study        = self.create_study(publishedAt=datetime.now(UTC))

--- a/tests/pages/test_api.py
+++ b/tests/pages/test_api.py
@@ -126,56 +126,6 @@ class TestApiPages(PageTest):
 
         self.assertEqual(response_json['error'], '404 Not found')
 
-
-    def test_updating_experiment(self):
-        user = self.create_user(apiKey='test1')
-
-        s1 = self.create_study(ownerUuid=user.uuid, publishedAt=datetime.now(UTC))
-        s2 = self.create_study(publishedAt=datetime.now(UTC))
-
-        e1 = self.create_experiment(studyId=s1.publicId)
-        e2 = self.create_experiment(studyId=s2.publicId)
-
-        self.db_session.commit()
-
-        payload = {
-            'apiKey': 'test1',
-            'model': {
-                'name': 'Test model',
-                'shortName': 'TM',
-                'description': 'Test model',
-            },
-            'entries': [{
-                'data': "time,value\n1,100\n2,200",
-            }]
-        }
-
-        # Study doesn't belong to this user, even if it's published
-        response = self.client.post(
-            f"/api/v1/experiment/{e2.publicId}/modeling.json",
-            data=json.dumps(payload),
-        )
-        response_json = self._get_json(response)
-        print(response_json)
-        self.assertEqual(response_json['error'], '403 Forbidden')
-
-        # Successful update:
-        response = self.client.post(
-            f"/api/v1/experiment/{e1.publicId}/modeling.json",
-            data=json.dumps(payload),
-        )
-        response_json = self._get_json(response)
-        self.assertEqual(response_json['status'], 'ok')
-
-        self.db_session.commit()
-
-        # Custom model exists now:
-        custom_model = self.db_session.get(CustomModel, response_json['customModelId'])
-        self.assertEqual(custom_model.study, s1)
-
-        # TODO (2026-07-09) Validate creation of modeling results
-
-
     def test_measurement_csv(self):
         study        = self.create_study(publishedAt=datetime.now(UTC))
         experiment   = self.create_experiment(studyId=study.publicId)
@@ -883,7 +833,8 @@ class TestApiPages(PageTest):
         bad_payload = {"apiKey": "wrong-api-key", "entries": []}
         response = self.client.post(api_url, data=json.dumps(bad_payload))
         response_json = self._get_json(response)
-        self.assertIn("API key", response_json["error"])
+        self.assertEqual(response_json["error"], "400 Bad request")
+        self.assertIn("API key", response_json["description"])
 
         # Missing api key: Forbidden
         bad_payload = {"entries": []}

--- a/tests/pages/test_api.py
+++ b/tests/pages/test_api.py
@@ -270,6 +270,88 @@ class TestApiPages(PageTest):
         response_json = self._get_json(response)
         self.assertEqual(response_json['modelPredictionIds'], [modeling_result.id])
 
+    def test_updating_model_predictions(self):
+        user = self.create_user(apiKey='test1')
+        study = self.create_study(
+            name='Example study',
+            publishedAt=datetime.now(UTC),
+            ownerUuid=user.uuid,
+        )
+        measurement_context = self.create_measurement_context(studyId=study.publicId)
+
+        self.db_session.commit()
+
+        response = self.client.get(f"/api/v1/measurement-context/{measurement_context.id}.json")
+        self.assertEqual(response.status, '200 OK')
+        response_json = self._get_json(response)
+
+        self.assertEqual(response_json['modelPredictionIds'], [])
+
+        # Push model prediction:
+        payload = {
+            'apiKey': 'test1',
+            'model': {
+                'name': 'Test model',
+                'shortName': 'TM',
+                'description': 'Test model',
+            },
+            'data': "time,value\n1,100\n2,200",
+        }
+        response = self.client.post(
+            f"/api/v1/measurement-context/{measurement_context.id}/model-predictions.json",
+            data=json.dumps(payload),
+        )
+        self.assertEqual(response.status, '200 OK')
+        response_json = self._get_json(response)
+
+        self.db_session.commit()
+
+        self.assertEqual(
+            [mr.id for mr in measurement_context.modelingResults],
+            [response_json['modelingResultId']],
+        )
+        self.assertEqual(measurement_context.modelingResults[0].yValues, [100, 200])
+
+        # Push another batch of data, overwrites the previous one by name:
+        payload = {
+            'apiKey': 'test1',
+            'model': {'name': 'Test model'},
+            'data': "time,value\n1,300\n2,400",
+        }
+        response = self.client.post(
+            f"/api/v1/measurement-context/{measurement_context.id}/model-predictions.json",
+            data=json.dumps(payload),
+        )
+        self.assertEqual(response.status, '200 OK')
+        response_json = self._get_json(response)
+
+        self.db_session.commit()
+
+        self.assertEqual(
+            [mr.id for mr in measurement_context.modelingResults],
+            [response_json['modelingResultId']],
+        )
+        self.assertEqual(measurement_context.modelingResults[0].yValues, [300, 400])
+        custom_model = measurement_context.modelingResults[0].customModel
+        self.assertEqual(custom_model.shortName, 'TM')
+
+        # Push another batch of data with a second new model:
+        payload = {
+            'apiKey': 'test1',
+            'model': {'name': 'Test model 2'},
+            'data': "time,value\n1,500\n2,600",
+        }
+        response = self.client.post(
+            f"/api/v1/measurement-context/{measurement_context.id}/model-predictions.json",
+            data=json.dumps(payload),
+        )
+        self.assertEqual(response.status, '200 OK')
+        response_json = self._get_json(response)
+
+        self.db_session.commit()
+
+        self.assertEqual(len(measurement_context.modelingResults), 2)
+
     def test_non_published_measurement_endpoints(self):
         study        = self.create_study(publishedAt=None)
         experiment   = self.create_experiment(studyId=study.publicId)

--- a/tests/pages/test_api.py
+++ b/tests/pages/test_api.py
@@ -241,7 +241,7 @@ class TestApiPages(PageTest):
         payload = {
             'apiKey': 'test1',
             'model': {
-                'name': 'Test model',
+                'name': 'Test model 1',
                 'shortName': 'TM',
                 'description': 'Test model',
             },
@@ -267,9 +267,8 @@ class TestApiPages(PageTest):
         # Check that the custom model information is available through the API
         response = self.client.get(f"/api/v1/model-prediction/{modeling_result.id}.json")
         response_json = self._get_json(response)
-        print(response_json)
         self.assertEqual(response_json['customModel'], {
-            'name': 'Test model',
+            'name': 'Test model 1',
             'shortName': 'TM',
             'description': 'Test model',
             'url': None,
@@ -278,7 +277,7 @@ class TestApiPages(PageTest):
         # Push another batch of data, overwrites the previous one by name:
         payload = {
             'apiKey': 'test1',
-            'model': {'name': 'Test model'},
+            'model': {'name': 'Test model 1'},
             'data': "time,value\n1,300\n2,400",
         }
         response = self.client.post(
@@ -309,11 +308,24 @@ class TestApiPages(PageTest):
             data=json.dumps(payload),
         )
         self.assertEqual(response.status, '200 OK')
-        response_json = self._get_json(response)
 
         self.db_session.commit()
 
         self.assertEqual(len(measurement_context.modelingResults), 2)
+
+        # Delete the first model's data:
+        payload = {'apiKey': 'test1', 'modelName': 'Test model 1'}
+        response = self.client.delete(
+            f"/api/v1/measurement-context/{measurement_context.id}/model-predictions.json",
+            data=json.dumps(payload),
+        )
+        response_json = self._get_json(response)
+        print(response_json)
+        self.assertEqual(response.status, '200 OK')
+        self.db_session.commit()
+
+        self.assertEqual(len(measurement_context.modelingResults), 1)
+        self.assertEqual(measurement_context.modelingResults[0].yValues, [500, 600])
 
     def test_non_published_measurement_endpoints(self):
         study        = self.create_study(publishedAt=None)

--- a/tests/pages/test_api.py
+++ b/tests/pages/test_api.py
@@ -260,7 +260,20 @@ class TestApiPages(PageTest):
             [mr.id for mr in measurement_context.modelingResults],
             [response_json['modelingResultId']],
         )
-        self.assertEqual(measurement_context.modelingResults[0].yValues, [100, 200])
+
+        modeling_result = measurement_context.modelingResults[0]
+        self.assertEqual(modeling_result.yValues, [100, 200])
+
+        # Check that the custom model information is available through the API
+        response = self.client.get(f"/api/v1/model-prediction/{modeling_result.id}.json")
+        response_json = self._get_json(response)
+        print(response_json)
+        self.assertEqual(response_json['customModel'], {
+            'name': 'Test model',
+            'shortName': 'TM',
+            'description': 'Test model',
+            'url': None,
+        })
 
         # Push another batch of data, overwrites the previous one by name:
         payload = {


### PR DESCRIPTION
This PR allows users to push custom model data through the API, for example from a script. Since the purpose of mGrowthDB is to contain data for sharing purposes, it would be nice to have a simple way to push model predictions. If a user re-uploads a study through a new submission, this deletes custom model uploads, since they're associated to measurement contexts that are deleted. Having a script that re-pushes them is a practical solution for now.

The new `/measurement-context/<id>/model-predictions.json` POST and DELETE endpoints work the same way as workspace pushing -- they require an API key inside a JSON payload of parameters.