### PR TITLE
Experiment filtering

### DIFF
--- a/app/model/lib/experiment_search.py
+++ b/app/model/lib/experiment_search.py
@@ -104,10 +104,20 @@ class ExperimentSearch:
 
         return results
 
+    def context_matches(self, measurement_context):
+        if measurement_context.subjectType == 'strain' and measurement_context.subjectId in self.strain_ids:
+            return True
+        elif measurement_context.subjectType == 'metabolite' and measurement_context.subjectId in self.metabolite_ids:
+            return True
+        else:
+            return False
+
+    def modeling_result_matches(self, modeling_result):
+        return modeling_result.type in self.modeling_types
+
 
 def _replace_public_id_references(text):
     return re.sub(r'\bEMGDB0*(\d+)', _replace_experiment_reference, text, flags=re.IGNORECASE)
-
 
 def _replace_experiment_reference(m):
     return f"EMGDB{int(m[1]):09d}"

--- a/app/model/lib/experiment_search.py
+++ b/app/model/lib/experiment_search.py
@@ -2,7 +2,12 @@ import re
 
 import sqlalchemy as sql
 
-from app.model.orm import Experiment, MeasurementContext, Bioreplicate
+from app.model.orm import (
+    Bioreplicate,
+    Experiment,
+    MeasurementContext,
+    ModelingResult,
+)
 
 
 class ExperimentSearch:
@@ -13,6 +18,7 @@ class ExperimentSearch:
         query=None,
         strain_ids=None,
         metabolite_ids=None,
+        modeling_types=None,
         sql_options=None,
     ):
         self.db_session = db_session
@@ -21,6 +27,7 @@ class ExperimentSearch:
         self.query          = (query or '').strip().lower()
         self.strain_ids     = strain_ids or []
         self.metabolite_ids = metabolite_ids or []
+        self.modeling_types = modeling_types or []
 
         self.sql_options = sql_options or ()
 
@@ -50,8 +57,10 @@ class ExperimentSearch:
         else:
             self.query_words = []
 
-        if self.strain_ids or self.metabolite_ids:
+        if self.strain_ids or self.metabolite_ids or self.modeling_types:
             db_query = db_query.join(Bioreplicate).join(MeasurementContext)
+            if self.modeling_types:
+                db_query = db_query.join(ModelingResult)
 
             strain_clause = sql.and_(
                 MeasurementContext.subjectId.in_(self.strain_ids),
@@ -68,6 +77,9 @@ class ExperimentSearch:
             db_query = db_query.where(strain_clause)
         elif self.metabolite_ids:
             db_query = db_query.where(metabolite_clause)
+
+        if self.modeling_types:
+            db_query = db_query.where(ModelingResult.type.in_(self.modeling_types))
 
         db_query = db_query.order_by(Experiment.publicId)
 

--- a/app/model/lib/experiment_search.py
+++ b/app/model/lib/experiment_search.py
@@ -4,9 +4,12 @@ import sqlalchemy as sql
 
 from app.model.orm import (
     Bioreplicate,
+    Community,
+    CommunityStrain,
     Experiment,
     MeasurementContext,
     ModelingResult,
+    StudyStrain,
 )
 
 
@@ -25,8 +28,8 @@ class ExperimentSearch:
         self.study      = study
 
         self.query          = (query or '').strip().lower()
-        self.strain_ids     = strain_ids or []
-        self.metabolite_ids = metabolite_ids or []
+        self.strain_ids     = [int(n) for n in (strain_ids or [])]
+        self.metabolite_ids = [int(n) for n in (metabolite_ids or [])]
         self.modeling_types = modeling_types or []
 
         self.sql_options = sql_options or ()
@@ -58,13 +61,27 @@ class ExperimentSearch:
             self.query_words = []
 
         if self.strain_ids or self.metabolite_ids or self.modeling_types:
-            db_query = db_query.join(Bioreplicate).join(MeasurementContext)
-            if self.modeling_types:
-                db_query = db_query.join(ModelingResult)
+            # Hack: We use left joins to avoid problems in tests where the
+            # entire hierarchy of data is not quite created consistently
+            db_query = db_query.join(Bioreplicate, isouter=True).join(MeasurementContext, isouter=True)
 
-            strain_clause = sql.and_(
-                MeasurementContext.subjectId.in_(self.strain_ids),
-                MeasurementContext.subjectType == 'strain',
+            if self.strain_ids:
+                db_query = (
+                    db_query
+                    .join(Community, isouter=True)
+                    .join(CommunityStrain, isouter=True)
+                    .join(StudyStrain, isouter=True)
+                )
+
+            if self.modeling_types:
+                db_query = db_query.join(ModelingResult, isouter=True)
+
+            strain_clause = sql.or_(
+                StudyStrain.id.in_(self.strain_ids),
+                sql.and_(
+                    MeasurementContext.subjectId.in_(self.strain_ids),
+                    MeasurementContext.subjectType == 'strain',
+                )
             )
             metabolite_clause = sql.and_(
                 MeasurementContext.subjectId.in_(self.metabolite_ids),

--- a/app/model/lib/experiment_search.py
+++ b/app/model/lib/experiment_search.py
@@ -1,0 +1,58 @@
+import re
+
+import sqlalchemy as sql
+
+from app.model.orm import Experiment
+
+
+class ExperimentSearch:
+    def __init__(
+        self,
+        db_session,
+        study,
+        query=None,
+        sql_options=(),
+    ):
+        self.db_session  = db_session
+        self.study       = study
+        self.query       = (query or '').strip().lower()
+        self.sql_options = sql_options
+
+        self.query_words = []
+
+    def fetch_results(self):
+        db_query = (
+            sql.select(Experiment)
+            .where(Experiment.studyId == self.study.publicId)
+            .options(*self.sql_options)
+        )
+
+        if len(self.query):
+            query = _replace_public_id_references(self.query)
+            self.query_words = query.split()
+
+            like_expr = '%' + '%'.join(self.query_words) + '%'
+
+            query_clause = sql.or_(
+                Experiment.name.ilike(like_expr),
+                Experiment.description.ilike(like_expr),
+                Experiment.publicId.in_(self.query_words),
+            )
+
+            db_query = db_query.where(query_clause)
+        else:
+            self.query_words = []
+
+        db_query = db_query.order_by(Experiment.publicId)
+
+        results = self.db_session.scalars(db_query).all()
+
+        return results
+
+
+def _replace_public_id_references(text):
+    return re.sub(r'\bEMGDB0*(\d+)', _replace_experiment_reference, text, flags=re.IGNORECASE)
+
+
+def _replace_experiment_reference(m):
+    return f"EMGDB{int(m[1]):09d}"

--- a/app/model/lib/experiment_search.py
+++ b/app/model/lib/experiment_search.py
@@ -2,7 +2,7 @@ import re
 
 import sqlalchemy as sql
 
-from app.model.orm import Experiment
+from app.model.orm import Experiment, MeasurementContext, Bioreplicate
 
 
 class ExperimentSearch:
@@ -11,18 +11,25 @@ class ExperimentSearch:
         db_session,
         study,
         query=None,
-        sql_options=(),
+        strain_ids=None,
+        metabolite_ids=None,
+        sql_options=None,
     ):
-        self.db_session  = db_session
-        self.study       = study
-        self.query       = (query or '').strip().lower()
-        self.sql_options = sql_options
+        self.db_session = db_session
+        self.study      = study
+
+        self.query          = (query or '').strip().lower()
+        self.strain_ids     = strain_ids or []
+        self.metabolite_ids = metabolite_ids or []
+
+        self.sql_options = sql_options or ()
 
         self.query_words = []
 
     def fetch_results(self):
         db_query = (
             sql.select(Experiment)
+            .group_by(Experiment.publicId)
             .where(Experiment.studyId == self.study.publicId)
             .options(*self.sql_options)
         )
@@ -42,6 +49,25 @@ class ExperimentSearch:
             db_query = db_query.where(query_clause)
         else:
             self.query_words = []
+
+        if self.strain_ids or self.metabolite_ids:
+            db_query = db_query.join(Bioreplicate).join(MeasurementContext)
+
+            strain_clause = sql.and_(
+                MeasurementContext.subjectId.in_(self.strain_ids),
+                MeasurementContext.subjectType == 'strain',
+            )
+            metabolite_clause = sql.and_(
+                MeasurementContext.subjectId.in_(self.metabolite_ids),
+                MeasurementContext.subjectType == 'metabolite',
+            )
+
+        if self.strain_ids and self.metabolite_ids:
+            db_query = db_query.where(sql.or_(strain_clause, metabolite_clause))
+        elif self.strain_ids:
+            db_query = db_query.where(strain_clause)
+        elif self.metabolite_ids:
+            db_query = db_query.where(metabolite_clause)
 
         db_query = db_query.order_by(Experiment.publicId)
 

--- a/app/model/lib/study_search.py
+++ b/app/model/lib/study_search.py
@@ -12,7 +12,7 @@ from app.model.orm import (
 )
 
 
-class StudySearch():
+class StudySearch:
     def __init__(
         self,
         db_session,

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -31,11 +31,9 @@ def study_show_page(publicId):
         publicId,
         check_user_visibility=False,
         sql_options=(
-            # Level 1:
+            sql.orm.selectinload(Study.strains, StudyStrain.taxon),
             sql.orm.selectinload(Study.experiments, Experiment.compartments),
             sql.orm.selectinload(Study.experiments, Experiment.community),
-            # Level 2:
-            sql.orm.selectinload(Study.experiments, Experiment.community, Community.strains),
         )
     )
 
@@ -67,6 +65,11 @@ def study_experiments_fragment(publicId):
             sql.orm.selectinload(Experiment.community, Community.strains),
             sql.orm.selectinload(Experiment.bioreplicates, Bioreplicate.measurementContexts),
             # Level 3:
+            sql.orm.selectinload(
+                Experiment.community,
+                Community.strains,
+                StudyStrain.taxon,
+            ),
             sql.orm.selectinload(
                 Experiment.bioreplicates,
                 Bioreplicate.measurementContexts,

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -15,6 +15,7 @@ from app.model.orm import (
     Community,
     Experiment,
     MeasurementContext,
+    ModelingResult,
     Study,
     StudyStrain,
     StudyUser,
@@ -37,10 +38,23 @@ def study_show_page(publicId):
         )
     )
 
-    if study.visible_to_user(g.current_user):
-        return render_template("pages/studies/show.html", study=study)
-    else:
+    if not study.visible_to_user(g.current_user):
         return render_template("pages/studies/show_unpublished.html", study=study)
+
+    study_model_types = g.db_session.scalars(
+        sql.select(ModelingResult.type)
+        .distinct()
+        .join(MeasurementContext)
+        .join(Bioreplicate)
+        .join(Study)
+        .where(Study.publicId == publicId)
+    ).all()
+
+    return render_template(
+        "pages/studies/show.html",
+        study=study,
+        study_model_types=study_model_types,
+    )
 
 
 def study_experiments_fragment(publicId):
@@ -57,6 +71,7 @@ def study_experiments_fragment(publicId):
         query=request.args.get('q'),
         strain_ids=request.args.getlist('strainIds'),
         metabolite_ids=request.args.getlist('metaboliteIds'),
+        modeling_types=request.args.getlist('modelingTypes'),
         sql_options=(
             # Level 1:
             sql.orm.selectinload(Experiment.compartments),

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -16,12 +16,14 @@ from app.model.orm import (
     Experiment,
     MeasurementContext,
     Study,
+    StudyStrain,
     StudyUser,
     Submission,
 )
 from app.view.forms.experiment_export_form import ExperimentExportForm
 from app.view.forms.comparative_chart_form import ComparativeChartForm
 import app.model.lib.util as util
+from app.model.lib.experiment_search import ExperimentSearch
 
 
 def study_show_page(publicId):
@@ -51,10 +53,11 @@ def study_experiments_fragment(publicId):
         .where(Experiment.studyId == study.publicId)
     ).one()
 
-    db_query = (
-        sql.select(Experiment)
-        .where(Experiment.studyId == publicId)
-        .options(
+    search = ExperimentSearch(
+        g.db_session,
+        study=study,
+        query=request.args.get('q'),
+        sql_options=(
             # Level 1:
             sql.orm.selectinload(Experiment.compartments),
             sql.orm.selectinload(Experiment.community),
@@ -81,19 +84,7 @@ def study_experiments_fragment(publicId):
             ),
         )
     )
-
-    # TODO (2026-07-20) Extract to testable class
-
-    if query := request.args.get('q'):
-        query_words = query.split()
-        like_expr = '%' + '%'.join(query_words) + '%'
-        query_clause = sql.or_(
-            Experiment.name.ilike(like_expr),
-            Experiment.description.ilike(like_expr),
-        )
-        db_query = db_query.where(query_clause)
-
-    experiments = g.db_session.scalars(db_query).all()
+    experiments = search.fetch_results()
 
     return render_template(
         "pages/studies/_experiments.html",

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -32,6 +32,25 @@ def study_show_page(publicId):
             # Level 1:
             sql.orm.selectinload(Study.experiments, Experiment.compartments),
             sql.orm.selectinload(Study.experiments, Experiment.community),
+            # Level 2:
+            sql.orm.selectinload(Study.experiments, Experiment.community, Community.strains),
+        )
+    )
+
+    if study.visible_to_user(g.current_user):
+        return render_template("pages/studies/show.html", study=study)
+    else:
+        return render_template("pages/studies/show_unpublished.html", study=study)
+
+
+def study_experiments_fragment(publicId):
+    study = _fetch_study_for_visitor(
+        publicId,
+        check_user_visibility=False,
+        sql_options=(
+            # Level 1:
+            sql.orm.selectinload(Study.experiments, Experiment.compartments),
+            sql.orm.selectinload(Study.experiments, Experiment.community),
             sql.orm.selectinload(Study.experiments, Experiment.perturbations),
             sql.orm.selectinload(Study.experiments, Experiment.bioreplicates),
             # Level 2:
@@ -59,10 +78,10 @@ def study_show_page(publicId):
         )
     )
 
-    if study.visible_to_user(g.current_user):
-        return render_template("pages/studies/show.html", study=study)
-    else:
-        return render_template("pages/studies/show_unpublished.html", study=study)
+    if not study.visible_to_user(g.current_user):
+        raise NotFound
+
+    return render_template("pages/studies/_experiments.html", experiments=study.experiments)
 
 
 def study_manage_page(publicId):

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -55,6 +55,8 @@ def study_experiments_fragment(publicId):
         g.db_session,
         study=study,
         query=request.args.get('q'),
+        strain_ids=request.args.getlist('strainIds'),
+        metabolite_ids=request.args.getlist('metaboliteIds'),
         sql_options=(
             # Level 1:
             sql.orm.selectinload(Experiment.compartments),

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -108,6 +108,7 @@ def study_experiments_fragment(publicId):
 
     return render_template(
         "pages/studies/_experiments.html",
+        search=search,
         experiments=experiments,
         total_experiment_count=total_experiment_count,
     )

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -44,33 +44,32 @@ def study_show_page(publicId):
 
 
 def study_experiments_fragment(publicId):
-    study = _fetch_study_for_visitor(
-        publicId,
-        check_user_visibility=False,
-        sql_options=(
+    study = _fetch_study_for_visitor(publicId)
+
+    db_query = (
+        sql.select(Experiment)
+        .where(Experiment.studyId == publicId)
+        .options(
             # Level 1:
-            sql.orm.selectinload(Study.experiments, Experiment.compartments),
-            sql.orm.selectinload(Study.experiments, Experiment.community),
-            sql.orm.selectinload(Study.experiments, Experiment.perturbations),
-            sql.orm.selectinload(Study.experiments, Experiment.bioreplicates),
+            sql.orm.selectinload(Experiment.compartments),
+            sql.orm.selectinload(Experiment.community),
+            sql.orm.selectinload(Experiment.perturbations),
+            sql.orm.selectinload(Experiment.bioreplicates),
             # Level 2:
-            sql.orm.selectinload(Study.experiments, Experiment.community, Community.strains),
-            sql.orm.selectinload(Study.experiments, Experiment.bioreplicates, Bioreplicate.measurementContexts),
+            sql.orm.selectinload(Experiment.community, Community.strains),
+            sql.orm.selectinload(Experiment.bioreplicates, Bioreplicate.measurementContexts),
             # Level 3:
             sql.orm.selectinload(
-                Study.experiments,
                 Experiment.bioreplicates,
                 Bioreplicate.measurementContexts,
                 MeasurementContext.measurements,
             ),
             sql.orm.selectinload(
-                Study.experiments,
                 Experiment.bioreplicates,
                 Bioreplicate.measurementContexts,
                 MeasurementContext.technique,
             ),
             sql.orm.selectinload(
-                Study.experiments,
                 Experiment.bioreplicates,
                 Bioreplicate.measurementContexts,
                 MeasurementContext.modelingResults,
@@ -78,10 +77,20 @@ def study_experiments_fragment(publicId):
         )
     )
 
-    if not study.visible_to_user(g.current_user):
-        raise NotFound
+    # TODO (2026-07-20) Extract to testable class
 
-    return render_template("pages/studies/_experiments.html", experiments=study.experiments)
+    if query := request.args.get('q'):
+        query_words = query.split()
+        like_expr = '%' + '%'.join(query_words) + '%'
+        query_clause = sql.or_(
+            Experiment.name.ilike(like_expr),
+            Experiment.description.ilike(like_expr),
+        )
+        db_query = db_query.where(query_clause)
+
+    experiments = g.db_session.scalars(db_query).all()
+
+    return render_template("pages/studies/_experiments.html", experiments=experiments)
 
 
 def study_manage_page(publicId):

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -46,6 +46,11 @@ def study_show_page(publicId):
 def study_experiments_fragment(publicId):
     study = _fetch_study_for_visitor(publicId)
 
+    total_experiment_count = g.db_session.scalars(
+        sql.select(sql.func.count(Experiment.publicId.distinct()))
+        .where(Experiment.studyId == study.publicId)
+    ).one()
+
     db_query = (
         sql.select(Experiment)
         .where(Experiment.studyId == publicId)
@@ -90,7 +95,11 @@ def study_experiments_fragment(publicId):
 
     experiments = g.db_session.scalars(db_query).all()
 
-    return render_template("pages/studies/_experiments.html", experiments=experiments)
+    return render_template(
+        "pages/studies/_experiments.html",
+        experiments=experiments,
+        total_experiment_count=total_experiment_count,
+    )
 
 
 def study_manage_page(publicId):

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -131,6 +131,15 @@ def study_export_page(publicId):
     )
 
 
+def study_export_experiments_fragment(publicId):
+    study = _fetch_study_for_visitor(publicId)
+
+    return render_template(
+        "pages/studies/export/_experiment_form.html",
+        experiments=study.experiments,
+    )
+
+
 def study_export_preview_fragment(publicId):
     # We only need the id here, but we call it to apply visibility checks:
     _fetch_study_for_visitor(publicId)
@@ -146,7 +155,10 @@ def study_export_preview_fragment(publicId):
             <pre>{csv}</pre>
         """)
 
-    return '\n'.join(csv_previews)
+    if csv_previews:
+        return '\n'.join(csv_previews)
+    else:
+        return """<p class="help margin-top-0">No experiments selected</p>"""
 
 
 def study_download_data_zip(publicId):

--- a/app/pages/studies.py
+++ b/app/pages/studies.py
@@ -134,9 +134,20 @@ def study_export_page(publicId):
 def study_export_experiments_fragment(publicId):
     study = _fetch_study_for_visitor(publicId)
 
+    search = ExperimentSearch(
+        g.db_session,
+        study=study,
+        query=request.args.get('q'),
+        strain_ids=request.args.getlist('strainIds'),
+        metabolite_ids=request.args.getlist('metaboliteIds'),
+        modeling_types=request.args.getlist('modelingTypes'),
+        sql_options=(sql.orm.selectinload(Experiment.bioreplicates),)
+    )
+    experiments = search.fetch_results()
+
     return render_template(
         "pages/studies/export/_experiment_form.html",
-        experiments=study.experiments,
+        experiments=experiments,
     )
 
 

--- a/app/view/css/search.css
+++ b/app/view/css/search.css
@@ -15,22 +15,6 @@
     background-color: var(--light-blue);
   }
 
-  .simple-form .form-row.small-input-row {
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius);
-    padding: 6px;
-    padding-top: 0;
-    font-size: 12px;
-
-    label span {
-      font-size: 12px;
-    }
-
-    select {
-      padding: 0.4rem;
-    }
-  }
-
   .results-list {
     transition: opacity var(--transition-length);
     border: 1px solid var(--border-color);

--- a/app/view/css/study.css
+++ b/app/view/css/study.css
@@ -76,6 +76,10 @@
     }
   }
 
+  .highlight {
+    background-color: var(--light-blue);
+  }
+
   .experiments-toc {
     position: sticky;
     top: 20px;

--- a/app/view/css/study.css
+++ b/app/view/css/study.css
@@ -28,6 +28,15 @@
     margin-left: 10px;
   }
 
+  .experiment-filter-form {
+    fieldset {
+      padding: 6px;
+    }
+    fieldset legend {
+      margin-bottom: -6px;
+    }
+  }
+
   .uncompare {
     .white-button {
       background-color: #eee;

--- a/app/view/css/study.css
+++ b/app/view/css/study.css
@@ -22,6 +22,12 @@
     margin-top: 0;
   }
 
+  .loader-image {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 10px;
+  }
+
   .uncompare {
     .white-button {
       background-color: #eee;

--- a/app/view/css/utils.css
+++ b/app/view/css/utils.css
@@ -319,6 +319,36 @@ form.simple-form {
     }
   }
 
+  fieldset {
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+  }
+
+  .form-row.small-input-row {
+    padding: 6px;
+    padding-top: 0;
+    font-size: 12px;
+
+    label span {
+      font-size: 12px;
+    }
+
+    select {
+      padding: 0.4rem;
+    }
+
+    input[type="text"] {
+      padding: 0.5rem;
+    }
+
+    input[type="submit"],
+    input[type="reset"],
+    button {
+      padding: 0.5rem;
+    }
+  }
+
+
   input[type="reset"],
   button[type="reset"] {
     cursor: pointer;

--- a/app/view/js/export.js
+++ b/app/view/js/export.js
@@ -1,45 +1,88 @@
 Page('.export-page', function($page) {
   let studyId = $page.data('studyId');
+  let select2Selectors = '.js-strain-select,.js-metabolite-select'
 
-  let $form    = $page.find('form');
-  let $preview = $page.find('.js-preview');
+  // Initialize select filters:
+  $page.find(select2Selectors).each(function() {
+    let $select = $(this);
 
-  $form.on('change', function() { updatePreview($form); });
-  $form.on('keyup', 'input[name=custom_delimiter]', function() { updatePreview($form); });
+    $select.select2({
+      multiple: true,
+      theme: 'custom',
+      width: '100%',
+      templateResult: select2Highlighter,
+    });
 
-  updatePreview($form);
-
-  $form.on('focus', 'input[name=custom_delimiter]', function() {
-    $form.find('input[name=delimiter][value=custom]').prop('checked', true);
+    $select.trigger('change');
   });
 
-  $form.on('click', '.js-select-all', function() {
+  $page.on('change', select2Selectors, updateFilter)
+  $page.on('change', '.js-filter-form', updateFilter);
+  $page.on('change', '.js-experiment-form', updatePreview);
+  $page.on('keyup', 'input[name=custom_delimiter]', updatePreview);
+
+  updateFilter();
+
+  $page.on('focus', 'input[name=custom_delimiter]', function() {
+    $page.find('input[name=delimiter][value=custom]').prop('checked', true);
+  });
+
+  $page.on('click', '.js-select-all', function() {
+    let $form = $(this).parents('form');
+
     $form.find('.section-experiment input[type=checkbox]').prop('checked', true);
-    updatePreview($form);
+    updatePreview();
   });
 
-  $form.on('click', '.js-select-average', function() {
+  $page.on('click', '.js-select-average', function() {
+    let $form = $(this).parents('form');
+
     $form.find('.section-experiment input[type=checkbox]').prop('checked', false);
     $form.find('.section-experiment input[type=checkbox].js-average').prop('checked', true);
-    updatePreview($form);
+    updatePreview();
   });
 
-  $form.on('click', '.js-select-none', function() {
+  $page.on('click', '.js-select-none', function() {
+    let $form = $(this).parents('form');
+
     $form.find('.section-experiment input[type=checkbox]').prop('checked', false);
-    updatePreview($form);
+    updatePreview();
   });
 
-  function updatePreview($form) {
+  function updateFilter() {
+    let $filterForm  = $page.find('.js-filter-form');
+    let $experimentForm = $page.find('.js-experiment-form');
+
+    let $searchInput = $filterForm.find('input[name=q]');
+    $searchInput.addClass('loading-input');
+
+    $filterForm.ajaxSubmit({
+      success: function(response) {
+        $experimentForm.html(response);
+        $searchInput.removeClass('loading-input');
+        updatePreview();
+      }
+    });
+  }
+
+  function updatePreview() {
+    // Form with CSV options:
+    let $filterForm = $page.find('.js-filter-form');
+
+    // Form with bioreplicates:
+    let $experimentForm = $page.find('.js-experiment-form');
+
+    let data = $filterForm.serializeArray();
+    data.push(...$experimentForm.serializeArray());
+
     $.ajax({
       url: `/study/${studyId}/export/preview`,
       method: 'POST',
       dataType: 'html',
-      data: $form.serializeArray(),
+      data: data,
       success: function(response) {
-        $preview.html(response);
+        $page.find('.js-preview').html(response);
       }
-    })
-
-    $form.find('.js-export-url').val($form.prop('action') + '?' + $form.serialize())
+    });
   }
 });

--- a/app/view/js/export.js
+++ b/app/view/js/export.js
@@ -19,6 +19,11 @@ Page('.export-page', function($page) {
   $page.on('change', '.js-export-options-inputs input,select', updateFilter)
   $page.on('keyup', 'input[name=q]', _.debounce(updateFilter, 200));
   $page.on('change', select2Selectors, updateFilter)
+
+  $page.on('submit', '.js-filter-form', function(e) {
+    e.preventDefault();
+    updateFilter();
+  });
   $page.on('click', '.js-filter-form .js-reset', function() {
     let $form = $(this).parents('form');
 

--- a/app/view/js/export.js
+++ b/app/view/js/export.js
@@ -16,8 +16,20 @@ Page('.export-page', function($page) {
     $select.trigger('change');
   });
 
+  $page.on('change', '.js-export-options-inputs input,select', updateFilter)
+  $page.on('keyup', 'input[name=q]', _.debounce(updateFilter, 200));
   $page.on('change', select2Selectors, updateFilter)
-  $page.on('change', '.js-filter-form', updateFilter);
+  $page.on('click', '.js-filter-form .js-reset', function() {
+    let $form = $(this).parents('form');
+
+    $form.find('input[name=q]').val(null);
+    $form.find(select2Selectors).each(function() {
+      $(this).val(null).trigger('change');
+    });
+
+    setTimeout(updateFilter, 1);
+  });
+
   $page.on('change', '.js-experiment-form', updatePreview);
   $page.on('keyup', 'input[name=custom_delimiter]', updatePreview);
 
@@ -54,12 +66,16 @@ Page('.export-page', function($page) {
     let $experimentForm = $page.find('.js-experiment-form');
 
     let $searchInput = $filterForm.find('input[name=q]');
+    let $headingLoader = $page.find('.js-experiments-heading .inline-loader-image');
+
     $searchInput.addClass('loading-input');
+    $headingLoader.removeClass('hidden');
 
     $filterForm.ajaxSubmit({
       success: function(response) {
         $experimentForm.html(response);
         $searchInput.removeClass('loading-input');
+        $headingLoader.addClass('hidden');
         updatePreview();
       }
     });
@@ -75,6 +91,9 @@ Page('.export-page', function($page) {
     let data = $filterForm.serializeArray();
     data.push(...$experimentForm.serializeArray());
 
+    let $headingLoader = $page.find('.js-preview-heading .inline-loader-image');
+    $headingLoader.removeClass('hidden');
+
     $.ajax({
       url: `/study/${studyId}/export/preview`,
       method: 'POST',
@@ -82,6 +101,7 @@ Page('.export-page', function($page) {
       data: data,
       success: function(response) {
         $page.find('.js-preview').html(response);
+        $headingLoader.addClass('hidden');
       }
     });
   }

--- a/app/view/js/search.js
+++ b/app/view/js/search.js
@@ -51,7 +51,7 @@ Page('.search-page', function($page) {
   }
 
   // Trigger initial update on page load:
-  updateSearch()
+  setTimeout(updateSearch, 1);
 
   $page.on('click', '.js-load-more', function(e) {
     e.preventDefault();

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -1,3 +1,14 @@
 Page('.study-page', function($page) {
   initCompareButtons($page);
+
+  $experiments = $('.js-experiments');
+
+  if ($experiments.length > 0) {
+    $.ajax({
+      url: $experiments.data('url'),
+      success: function(response) {
+        $experiments.html(response);
+      }
+    });
+  }
 });

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -9,6 +9,11 @@ Page('.study-page', function($page) {
 
     $page.on('keyup', 'input[name=q]', _.debounce(updateFilter, 200));
     $page.on('change', select2Selectors, updateFilter)
+
+    $filterForm.on('submit', function(e) {
+      e.preventDefault();
+      updateFilter();
+    });
     $filterForm.on('reset', function() {
       $page.find(select2Selectors).each(function() {
         $(this).val(null).trigger('change');

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -4,10 +4,28 @@ Page('.study-page', function($page) {
   $experiments = $('.js-experiments');
 
   if ($experiments.length > 0) {
-    $.ajax({
-      url: $experiments.data('url'),
+    let $searchForm  = $page.find('.js-search-form');
+
+    $page.on('keyup', 'input[name=q]', _.debounce(updateSearch, 200));
+    $searchForm.on('reset', function() {
+      setTimeout(updateSearch, 1);
+    });
+
+    // Trigger initial update on page load:
+    setTimeout(updateSearch, 1);
+  }
+
+  function updateSearch() {
+    let $searchForm  = $page.find('.js-search-form');
+    let $experiments = $page.find('.js-experiments');
+
+    let $searchInput = $searchForm.find('input[name=q]');
+    $searchInput.addClass('loading-input');
+
+    $searchForm.ajaxSubmit({
       success: function(response) {
         $experiments.html(response);
+        $searchInput.removeClass('loading-input');
       }
     });
   }

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -1,14 +1,19 @@
 Page('.study-page', function($page) {
   initCompareButtons($page);
 
-  $experiments = $('.js-experiments');
+  let $experiments = $('.js-experiments');
+  let select2_selectors = '.js-strain-select,.js-metabolite-select,.js-modeling-type-select'
 
   if ($experiments.length > 0) {
     let $searchForm  = $page.find('.js-search-form');
 
     $page.on('keyup', 'input[name=q]', _.debounce(updateSearch, 200));
-    $page.on('change', '.js-strain-select,.js-metabolite-select,.js-modeling-type-select', updateSearch)
+    $page.on('change', select2_selectors, updateSearch)
     $searchForm.on('reset', function() {
+      $page.find(select2_selectors).each(function() {
+        $(this).val(null).trigger('change');
+      });
+
       setTimeout(updateSearch, 1);
     });
 
@@ -16,7 +21,7 @@ Page('.study-page', function($page) {
     setTimeout(updateSearch, 1);
 
     // Initialize select filters:
-    $page.find('.js-strain-select,.js-metabolite-select,.js-modeling-type-select').each(function() {
+    $page.find(select2_selectors).each(function() {
       let $select = $(this);
 
       $select.select2({

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -7,12 +7,36 @@ Page('.study-page', function($page) {
     let $searchForm  = $page.find('.js-search-form');
 
     $page.on('keyup', 'input[name=q]', _.debounce(updateSearch, 200));
+    $page.on('change', '.js-strain-select,.js-metabolite-select', updateSearch)
     $searchForm.on('reset', function() {
       setTimeout(updateSearch, 1);
     });
 
     // Trigger initial update on page load:
     setTimeout(updateSearch, 1);
+
+    // Initialize selection of strains
+    let $strainSelect = $page.find('.js-strain-select');
+    $strainSelect.select2({
+      multiple: true,
+      width: '100%',
+      theme: 'custom',
+      templateResult: select2Highlighter,
+    });
+
+    // Initialize selection of metabolites
+    $page.find('.js-metabolite-select').each(function() {
+      let $select = $(this);
+
+      $select.select2({
+        multiple: true,
+        theme: 'custom',
+        width: '100%',
+        templateResult: select2Highlighter,
+      });
+
+      $select.trigger('change');
+    });
   }
 
   function updateSearch() {

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -7,7 +7,7 @@ Page('.study-page', function($page) {
     let $searchForm  = $page.find('.js-search-form');
 
     $page.on('keyup', 'input[name=q]', _.debounce(updateSearch, 200));
-    $page.on('change', '.js-strain-select,.js-metabolite-select', updateSearch)
+    $page.on('change', '.js-strain-select,.js-metabolite-select,.js-modeling-type-select', updateSearch)
     $searchForm.on('reset', function() {
       setTimeout(updateSearch, 1);
     });
@@ -15,17 +15,8 @@ Page('.study-page', function($page) {
     // Trigger initial update on page load:
     setTimeout(updateSearch, 1);
 
-    // Initialize selection of strains
-    let $strainSelect = $page.find('.js-strain-select');
-    $strainSelect.select2({
-      multiple: true,
-      width: '100%',
-      theme: 'custom',
-      templateResult: select2Highlighter,
-    });
-
-    // Initialize selection of metabolites
-    $page.find('.js-metabolite-select').each(function() {
+    // Initialize select filters:
+    $page.find('.js-strain-select,.js-metabolite-select,.js-modeling-type-select').each(function() {
       let $select = $(this);
 
       $select.select2({

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -2,26 +2,26 @@ Page('.study-page', function($page) {
   initCompareButtons($page);
 
   let $experiments = $('.js-experiments');
-  let select2_selectors = '.js-strain-select,.js-metabolite-select,.js-modeling-type-select'
+  let select2Selectors = '.js-strain-select,.js-metabolite-select,.js-modeling-type-select'
 
   if ($experiments.length > 0) {
-    let $searchForm  = $page.find('.js-search-form');
+    let $filterForm  = $page.find('.js-filter-form');
 
-    $page.on('keyup', 'input[name=q]', _.debounce(updateSearch, 200));
-    $page.on('change', select2_selectors, updateSearch)
-    $searchForm.on('reset', function() {
-      $page.find(select2_selectors).each(function() {
+    $page.on('keyup', 'input[name=q]', _.debounce(updateFilter, 200));
+    $page.on('change', select2Selectors, updateFilter)
+    $filterForm.on('reset', function() {
+      $page.find(select2Selectors).each(function() {
         $(this).val(null).trigger('change');
       });
 
-      setTimeout(updateSearch, 1);
+      setTimeout(updateFilter, 1);
     });
 
     // Trigger initial update on page load:
-    setTimeout(updateSearch, 1);
+    setTimeout(updateFilter, 1);
 
     // Initialize select filters:
-    $page.find(select2_selectors).each(function() {
+    $page.find(select2Selectors).each(function() {
       let $select = $(this);
 
       $select.select2({
@@ -35,14 +35,14 @@ Page('.study-page', function($page) {
     });
   }
 
-  function updateSearch() {
-    let $searchForm  = $page.find('.js-search-form');
+  function updateFilter() {
+    let $filterForm  = $page.find('.js-filter-form');
     let $experiments = $page.find('.js-experiments');
 
-    let $searchInput = $searchForm.find('input[name=q]');
+    let $searchInput = $filterForm.find('input[name=q]');
     $searchInput.addClass('loading-input');
 
-    $searchForm.ajaxSubmit({
+    $filterForm.ajaxSubmit({
       success: function(response) {
         $experiments.html(response);
         $searchInput.removeClass('loading-input');

--- a/app/view/templates/pages/experiments/_bioreplicates_list.html
+++ b/app/view/templates/pages/experiments/_bioreplicates_list.html
@@ -1,4 +1,4 @@
-{% macro render_bioreplicates_list(experiment) %}
+{% macro render_bioreplicates_list(experiment, search=None) %}
   {% set study = experiment.study %}
 
   <ol class="bioreplicates-list">
@@ -74,7 +74,7 @@
                 {% set measurements = measurement_context.measurements %}
                 {% set technique    = measurement_context.technique %}
 
-                <div class="js-table-row">
+                <div class="js-table-row {{ "highlight" if search and search.context_matches(measurement_context) }}">
                   <div class="button-group" style="display: inline-block; margin-right: 6px;">
                     <span class="js-compare-container" data-context-ids="{{ measurement_context.id }}">
                       <span class="js-compare">
@@ -124,7 +124,7 @@
 
                   <ul class="small">
                     {% for modeling_result in measurement_context.publishedModelingResults: %}
-                      <li>
+                      <li class="{{ "highlight" if search and search.modeling_result_matches(modeling_result) }}">
                         <div class="button-group" style="display: inline-block; margin-right: 6px;">
                           <span class="js-compare-container" data-model-ids="{{ modeling_result.id }}">
                             <span class="js-compare" data-tooltip="Compare">

--- a/app/view/templates/pages/studies/_experiments.html
+++ b/app/view/templates/pages/studies/_experiments.html
@@ -77,7 +77,7 @@
 
   {% if experiments|length: %}
     <div class="toc-container">
-      {{ render_experiments_toc(experiments) }}
+      {{ render_experiments_toc(experiments, total_experiment_count) }}
     </div>
   {% else: %}
     <p class="help">

--- a/app/view/templates/pages/studies/_experiments.html
+++ b/app/view/templates/pages/studies/_experiments.html
@@ -1,73 +1,87 @@
 {% from 'utils/_strain_link.html' import render_strain_link %}
 {% from 'pages/experiments/_bioreplicates_list.html' import render_bioreplicates_list %}
 {% from 'pages/perturbations/_perturbation.html' import render_perturbation %}
+{% from 'pages/studies/_experiments_toc.html' import render_experiments_toc %}
 
-{% for experiment in experiments: %}
-  <div class="experiment-container">
-    <h2 id="experiment-{{ experiment.publicId }}">
-      Experiment {{ loop.index }}: {{ experiment.name }}
-    </h2>
+<div class="flex-row">
+  <div>
+    {% for experiment in experiments: %}
+      <div class="experiment-container">
+        <h2 id="experiment-{{ experiment.publicId }}">
+          Experiment {{ loop.index }}: {{ experiment.name }}
+        </h2>
 
-    {% if experiment.publicId: %}
-      <p class="small">
-        <strong>Public ID</strong>:
-        <a href="{{ url_for('experiment_show_page', publicId=experiment.publicId) }}">
-          {{ experiment.publicId }}
-        </a>
+        {% if experiment.publicId: %}
+          <p class="small">
+            <strong>Public ID</strong>:
+            <a href="{{ url_for('experiment_show_page', publicId=experiment.publicId) }}">
+              {{ experiment.publicId }}
+            </a>
+            <br>
+          </p>
+        {% endif %}
+
+        {% if experiment.description: %}
+          {{ experiment.description|format_text }}
+        {% endif %}
+
         <br>
-      </p>
-    {% endif %}
 
-    {% if experiment.description: %}
-      {{ experiment.description|format_text }}
-    {% endif %}
+        <h3>Compartments</h3>
 
-    <br>
+        <ol>
+          {% for compartment in experiment.compartments: %}
+            <li>
+              <strong>{{ compartment.name }}</strong>
 
-    <h3>Compartments</h3>
+              <br>
 
-    <ol>
-      {% for compartment in experiment.compartments: %}
-        <li>
-          <strong>{{ compartment.name }}</strong>
+              Medium:
+              {% if compartment.mediumUrl: %}
+                {{ compartment.mediumUrl|external_link(compartment.mediumName) }}
+              {% else: %}
+                {{ compartment.mediumName }}
+              {% endif %}
 
-          <br>
+              <br>
 
-          Medium:
-          {% if compartment.mediumUrl: %}
-            {{ compartment.mediumUrl|external_link(compartment.mediumName) }}
-          {% else: %}
-            {{ compartment.mediumName }}
-          {% endif %}
+              Properties: {{ compartment.properties_description|safe }}
+            </li>
+          {% endfor %}
+        </ol>
 
-          <br>
+        <h3>Community: {{ experiment.community.name }}</h3>
 
-          Properties: {{ compartment.properties_description|safe }}
-        </li>
-      {% endfor %}
-    </ol>
+        <ol>
+          {% for strain in experiment.community.strains|sort: %}
+            <li>{{ render_strain_link(strain) }}</li>
+          {% endfor %}
+        </ol>
 
-    <h3>Community: {{ experiment.community.name }}</h3>
+        {% if experiment.perturbations|length > 0: %}
+          <h3>Perturbations</h3>
 
-    <ol>
-      {% for strain in experiment.community.strains|sort: %}
-        <li>{{ render_strain_link(strain) }}</li>
-      {% endfor %}
-    </ol>
+          <ol>
+            {% for perturbation in experiment.perturbations: %}
+              <li>{{ render_perturbation(perturbation, link=True) }}</li>
+            {% endfor %}
+          </ol>
+        {% endif %}
 
-    {% if experiment.perturbations|length > 0: %}
-      <h3>Perturbations</h3>
+        <h3>Biological replicates</h3>
 
-      <ol>
-        {% for perturbation in experiment.perturbations: %}
-          <li>{{ render_perturbation(perturbation, link=True) }}</li>
-        {% endfor %}
-      </ol>
-    {% endif %}
-
-    <h3>Biological replicates</h3>
-
-    {{ render_bioreplicates_list(experiment) }}
+        {{ render_bioreplicates_list(experiment) }}
+      </div>
+    {% endfor %}
   </div>
-{% endfor %}
 
+  {% if experiments|length: %}
+    <div class="toc-container">
+      {{ render_experiments_toc(experiments) }}
+    </div>
+  {% else: %}
+    <p class="help">
+      No experiments found matching the given filter.
+    </p>
+  {% endif %}
+</div>

--- a/app/view/templates/pages/studies/_experiments.html
+++ b/app/view/templates/pages/studies/_experiments.html
@@ -1,0 +1,73 @@
+{% from 'utils/_strain_link.html' import render_strain_link %}
+{% from 'pages/experiments/_bioreplicates_list.html' import render_bioreplicates_list %}
+{% from 'pages/perturbations/_perturbation.html' import render_perturbation %}
+
+{% for experiment in experiments: %}
+  <div class="experiment-container">
+    <h2 id="experiment-{{ experiment.publicId }}">
+      Experiment {{ loop.index }}: {{ experiment.name }}
+    </h2>
+
+    {% if experiment.publicId: %}
+      <p class="small">
+        <strong>Public ID</strong>:
+        <a href="{{ url_for('experiment_show_page', publicId=experiment.publicId) }}">
+          {{ experiment.publicId }}
+        </a>
+        <br>
+      </p>
+    {% endif %}
+
+    {% if experiment.description: %}
+      {{ experiment.description|format_text }}
+    {% endif %}
+
+    <br>
+
+    <h3>Compartments</h3>
+
+    <ol>
+      {% for compartment in experiment.compartments: %}
+        <li>
+          <strong>{{ compartment.name }}</strong>
+
+          <br>
+
+          Medium:
+          {% if compartment.mediumUrl: %}
+            {{ compartment.mediumUrl|external_link(compartment.mediumName) }}
+          {% else: %}
+            {{ compartment.mediumName }}
+          {% endif %}
+
+          <br>
+
+          Properties: {{ compartment.properties_description|safe }}
+        </li>
+      {% endfor %}
+    </ol>
+
+    <h3>Community: {{ experiment.community.name }}</h3>
+
+    <ol>
+      {% for strain in experiment.community.strains|sort: %}
+        <li>{{ render_strain_link(strain) }}</li>
+      {% endfor %}
+    </ol>
+
+    {% if experiment.perturbations|length > 0: %}
+      <h3>Perturbations</h3>
+
+      <ol>
+        {% for perturbation in experiment.perturbations: %}
+          <li>{{ render_perturbation(perturbation, link=True) }}</li>
+        {% endfor %}
+      </ol>
+    {% endif %}
+
+    <h3>Biological replicates</h3>
+
+    {{ render_bioreplicates_list(experiment) }}
+  </div>
+{% endfor %}
+

--- a/app/view/templates/pages/studies/_experiments.html
+++ b/app/view/templates/pages/studies/_experiments.html
@@ -8,21 +8,22 @@
     {% for experiment in experiments: %}
       <div class="experiment-container">
         <h2 id="experiment-{{ experiment.publicId }}">
-          Experiment {{ loop.index }}: {{ experiment.name }}
+          Experiment {{ loop.index }}:
+          {{ experiment.name|highlight(search.query_words) }}
         </h2>
 
         {% if experiment.publicId: %}
           <p class="small">
             <strong>Public ID</strong>:
             <a href="{{ url_for('experiment_show_page', publicId=experiment.publicId) }}">
-              {{ experiment.publicId }}
+              {{ experiment.publicId|highlight(search.query_words) }}
             </a>
             <br>
           </p>
         {% endif %}
 
         {% if experiment.description: %}
-          {{ experiment.description|format_text }}
+          {{ experiment.description|highlight(search.query_words)|format_text }}
         {% endif %}
 
         <br>
@@ -54,7 +55,9 @@
 
         <ol>
           {% for strain in experiment.community.strains|sort: %}
-            <li>{{ render_strain_link(strain) }}</li>
+            <li class="{{ "highlight" if strain.id in search.strain_ids }}">
+              {{ render_strain_link(strain) }}
+            </li>
           {% endfor %}
         </ol>
 
@@ -70,7 +73,7 @@
 
         <h3>Biological replicates</h3>
 
-        {{ render_bioreplicates_list(experiment) }}
+        {{ render_bioreplicates_list(experiment, search) }}
       </div>
     {% endfor %}
   </div>

--- a/app/view/templates/pages/studies/_experiments_toc.html
+++ b/app/view/templates/pages/studies/_experiments_toc.html
@@ -1,7 +1,18 @@
-{% macro render_experiments_toc(experiments) %}
+{% macro render_experiments_toc(experiments, total_experiment_count=None) %}
+  {% set experiment_count = experiments|length %}
 
   <div class="box experiments-toc scroll-shadows">
-    <h2>Experiments</h2>
+    <h2>
+      Experiments
+
+      {% if total_experiment_count is not none: %}
+        {% if total_experiment_count != experiment_count: %}
+          ({{ experiment_count }}/{{ total_experiment_count }})
+        {% else: %}
+          ({{ experiment_count }})
+        {% endif %}
+      {% endif %}
+    </h2>
 
     <ol>
       {% for experiment in experiments: %}

--- a/app/view/templates/pages/studies/export.html
+++ b/app/view/templates/pages/studies/export.html
@@ -18,12 +18,9 @@
 
       {% include 'pages/studies/_navigation_buttons.html' %}
 
-      <p>{{ study.description }}</p>
-
       <form
-          class="simple-form"
-          action="{{ url_for('study_download_data_zip', publicId=studyId) }}"
-          method="POST">
+          action="{{ url_for('study_export_experiments_fragment', publicId=study.publicId) }}"
+          class="simple-form experiment-filter-form margin-top-10 js-filter-form">
         <h2 style="margin-bottom: 0">
           Export options
         </h2>
@@ -108,69 +105,103 @@
           </div>
         </div>
 
-        <div class="flex-row columns">
-          <div class="flex-column column-left">
-            <div class="section-all-none">
-              <h2>Biological replicates</h3>
+        <h2 style="margin-bottom: 0">
+          Filter experiments
+        </h2>
 
-              <div class="form-row">
-                <button type="submit" class="green-button full">
-                  <span class="icon icon-inline icon-download-white"></span>
-                  Download ZIP file
-                </button>
-              </div>
+        <div class="form-row full">
+          <label class="full">
+            <span>By text:</span>
+            <input
+                type="text"
+                name="q"
+                tabindex="1"
+                autocomplete="off"
+                value="{{ request.args.get('q') or '' }}"
+                placeholder="Text included in the experiment"
+                class="form-input-full form-input-blue" />
+          </label>
 
-              <div class="form-row margin-top-10 small flex-row">
-                <button type="button" class="js-select-all white-button flex-1">
-                  Select all
-                </button>
-                <button type="button" class="js-select-none white-button flex-1">
-                  Select none
-                </button>
-                <button type="button" class="js-select-average white-button flex-1">
-                  Select averages
-                </button>
-              </div>
-            </div>
-
-            {% for experiment in study.experiments: %}
-              <div class="section-experiment">
-                <h4>Experiment: {{ experiment.name }}</h4>
-
-                {{ experiment.description|format_text }}
-
-                <div class="section-bioreplicates box">
-                  {% for bioreplicate in experiment.bioreplicates: %}
-                    <label>
-                      <input
-                          type="checkbox"
-                          class="{{ 'js-average' if bioreplicate.calculationType == 'average' }}"
-                          name="bioreplicates"
-                          value="{{ bioreplicate.id }}"
-                          checked />
-                      {{ bioreplicate.name }}
-                    </label>
-                  {% endfor %}
-                </div>
-              </div>
-            {% endfor %}
-
-            <div class="form-row submit-row margin-top-10">
-              <button type="submit" class="green-button full">
-                <span class="icon icon-inline icon-download-white"></span>
-                Download ZIP file
-              </button>
-            </div>
-          </div>
-
-          <div class="flex-column column-right">
-            <h2>Preview (first 5 rows)</h2>
-
-            <div class="preview js-preview box">
-
-            </div>
-          </div>
+          <input class="flex-end" type="submit" value="🔍 Search" />
+          <input class="flex-end white-button" type="reset" value="🧹 Clear" />
         </div>
+
+        <div class="form-row full">
+          {% if study.strains: %}
+            <label class="flex-1">
+              <span>By microbial strain:</span>
+              <select
+                  tabindex="2"
+                  name="strainIds"
+                  multiple="multiple"
+                  class="strain-select js-strain-select">
+                {% for study_strain in study.strains: %}
+                  <option value="{{ study_strain.id }}">{{ study_strain.name }} (NCBI:{{ study_strain.taxon.ncbiId }})</option>
+                {% endfor %}
+              </select>
+            </label>
+          {% endif %}
+
+          {% if study.metabolites: %}
+            <label class="flex-1">
+              <span>By metabolite:</span>
+              <select
+                  tabindex="3"
+                  name="metaboliteIds"
+                  multiple="multiple"
+                  class="metabolite-select js-metabolite-select">
+                {% for metabolite in study.metabolites: %}
+                  <option value="{{ metabolite.id }}">{{ metabolite.name }} ({{ metabolite.chebiId }})</option>
+                {% endfor %}
+              </select>
+            </label>
+          {% endif %}
+
+          {% if study_model_types: %}
+            <label class="flex-1">
+              <span>With model predictions:</span>
+              <select
+                  name="modelingTypes"
+                  multiple="multiple"
+                  tabindex="4"
+                  class="form-input-blue form-input-full js-modeling-type-select">
+                {% if 'easy_linear' in study_model_types: %}
+                  <option value="easy_linear">"Easy linear" method</option>
+                {% endif %}
+                {% if 'logistic' in study_model_types: %}
+                  <option value="logistic">Logistic model</option>
+                {% endif %}
+                {% if 'baranyi_roberts' in study_model_types: %}
+                  <option value="baranyi_roberts">Baranyi-Roberts model</option>
+                {% endif %}
+
+                {% if study.customModels: %}
+                  {% for m in study.customModels:  %}
+                    <option
+                        {{ "selected" if m.id == selectedCustomModelId }}
+                        value="custom_{{ m.id }}"
+                        data-custom-model-id="{{ m.id }}">
+                    {{ m.name }}
+                    </option>
+                  {% endfor %}
+                {% endif %}
+              </select>
+            </label>
+          {% endif %}
+        </div>
+      </form>
+
+      <form
+          class="simple-form js-experiment-form"
+          action="{{ url_for('study_download_data_zip', publicId=studyId) }}"
+          method="POST">
+        <h2>
+          Loading export form
+
+          <img
+              class="inline-loader-image loader-image"
+              src="{{ url_for('static', filename="images/loader.svg") }}" />
+        </h2>
       </form>
     </article>
   </div>

--- a/app/view/templates/pages/studies/export.html
+++ b/app/view/templates/pages/studies/export.html
@@ -25,7 +25,7 @@
           Export options
         </h2>
 
-        <div class="flex-row columns">
+        <div class="flex-row columns js-export-options-inputs">
           <div class="section-delimiter measurement-inputs">
             <h4>Measurement units</h4>
 
@@ -123,7 +123,7 @@
           </label>
 
           <input class="flex-end" type="submit" value="🔍 Search" />
-          <input class="flex-end white-button" type="reset" value="🧹 Clear" />
+          <input class="flex-end white-button js-reset" type="button" value="🧹 Clear" />
         </div>
 
         <div class="form-row full">
@@ -200,6 +200,7 @@
 
           <img
               class="inline-loader-image loader-image"
+              style="width: 22px; height: 22px;"
               src="{{ url_for('static', filename="images/loader.svg") }}" />
         </h2>
       </form>

--- a/app/view/templates/pages/studies/export/_experiment_form.html
+++ b/app/view/templates/pages/studies/export/_experiment_form.html
@@ -1,7 +1,14 @@
 <div class="flex-row columns">
   <div class="flex-column column-left">
     <div class="section-all-none">
-      <h2>Biological replicates</h3>
+      <h2 class="js-experiments-heading">
+        Biological replicates
+
+        <img
+            class="inline-loader-image loader-image hidden"
+            style="width: 22px; height: 22px;"
+            src="{{ url_for('static', filename="images/loader.svg") }}" />
+      </h2>
 
       <div class="form-row">
         <button type="submit" class="green-button full">
@@ -54,7 +61,14 @@
   </div>
 
   <div class="flex-column column-right">
-    <h2>Preview (first 5 rows)</h2>
+    <h2 class="js-preview-heading">
+      Preview (first 5 rows)
+
+      <img
+          class="inline-loader-image loader-image hidden"
+          style="width: 22px; height: 22px;"
+          src="{{ url_for('static', filename="images/loader.svg") }}" />
+    </h2>
 
     <div class="preview js-preview box">
       <p class="help margin-top-0">Loading preview...</p>

--- a/app/view/templates/pages/studies/export/_experiment_form.html
+++ b/app/view/templates/pages/studies/export/_experiment_form.html
@@ -1,0 +1,63 @@
+<div class="flex-row columns">
+  <div class="flex-column column-left">
+    <div class="section-all-none">
+      <h2>Biological replicates</h3>
+
+      <div class="form-row">
+        <button type="submit" class="green-button full">
+          <span class="icon icon-inline icon-download-white"></span>
+          Download ZIP file
+        </button>
+      </div>
+
+      <div class="form-row margin-top-10 small flex-row">
+        <button type="button" class="js-select-all white-button flex-1">
+          Select all
+        </button>
+        <button type="button" class="js-select-none white-button flex-1">
+          Select none
+        </button>
+        <button type="button" class="js-select-average white-button flex-1">
+          Select averages
+        </button>
+      </div>
+    </div>
+
+    {% for experiment in experiments: %}
+      <div class="section-experiment">
+        <h4>Experiment: {{ experiment.name }}</h4>
+
+        {{ experiment.description|format_text }}
+
+        <div class="section-bioreplicates box">
+          {% for bioreplicate in experiment.bioreplicates: %}
+            <label>
+              <input
+                  type="checkbox"
+                  class="{{ 'js-average' if bioreplicate.calculationType == 'average' }}"
+                  name="bioreplicates"
+                  value="{{ bioreplicate.id }}"
+                  checked />
+              {{ bioreplicate.name }}
+            </label>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+
+    <div class="form-row submit-row margin-top-10">
+      <button type="submit" class="green-button full">
+        <span class="icon icon-inline icon-download-white"></span>
+        Download ZIP file
+      </button>
+    </div>
+  </div>
+
+  <div class="flex-column column-right">
+    <h2>Preview (first 5 rows)</h2>
+
+    <div class="preview js-preview box">
+      <p class="help margin-top-0">Loading preview...</p>
+    </div>
+  </div>
+</div>

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -212,6 +212,34 @@
           <input class="flex-end" type="submit" value="🔍 Search" />
           <input class="flex-end white-button" type="reset" value="🧹 Clear" />
         </div>
+
+        <div class="form-row full">
+          <label class="flex-1">
+            <span>By microbial strain:</span>
+            <select
+                tabindex="2"
+                name="strainIds"
+                multiple="multiple"
+                class="strain-select js-strain-select">
+              {% for study_strain in study.strains: %}
+                <option value="{{ study_strain.id }}">{{ study_strain.name }} (NCBI:{{ study_strain.taxon.ncbiId }})</option>
+              {% endfor %}
+            </select>
+          </label>
+
+          <label class="flex-1">
+            <span>By metabolite:</span>
+            <select
+                tabindex="3"
+                name="metaboliteIds"
+                multiple="multiple"
+                class="metabolite-select js-metabolite-select">
+              {% for metabolite in study.metabolites: %}
+                <option value="{{ metabolite.id }}">{{ metabolite.name }} ({{ metabolite.chebiId }})</option>
+              {% endfor %}
+            </select>
+          </label>
+        </div>
       </form>
 
       <div

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -195,7 +195,7 @@
 
       <form
           action="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
-          class="simple-form margin-top-10 js-search-form">
+          class="simple-form experiment-filter-form margin-top-10 js-search-form">
         <fieldset>
           <legend class="small">Filter experiments</legend>
           <div class="form-row small-input-row full">

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -239,6 +239,38 @@
               {% endfor %}
             </select>
           </label>
+
+          {% if study_model_types: %}
+            <label class="flex-1">
+              <span>With model predictions:</span>
+              <select
+                  name="modelingTypes"
+                  multiple="multiple"
+                  tabindex="4"
+                  class="form-input-blue form-input-full js-modeling-type-select">
+                {% if 'easy_linear' in study_model_types: %}
+                  <option value="easy_linear">"Easy linear" method</option>
+                {% endif %}
+                {% if 'logistic' in study_model_types: %}
+                  <option value="logistic">Logistic model</option>
+                {% endif %}
+                {% if 'baranyi_roberts' in study_model_types: %}
+                  <option value="baranyi_roberts">Baranyi-Roberts model</option>
+                {% endif %}
+
+                {% if study.customModels: %}
+                  {% for m in study.customModels:  %}
+                    <option
+                        {{ "selected" if m.id == selectedCustomModelId }}
+                        value="custom_{{ m.id }}"
+                        data-custom-model-id="{{ m.id }}">
+                      {{ m.name }}
+                    </option>
+                  {% endfor %}
+                {% endif %}
+              </select>
+            </label>
+          {% endif %}
         </div>
       </form>
 

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -196,82 +196,89 @@
       <form
           action="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
           class="simple-form margin-top-10 js-search-form">
-        <div class="form-row full">
-          <label class="full">
-            <span>Filter by text:</span>
-            <input
-                type="text"
-                name="q"
-                tabindex="1"
-                autocomplete="off"
-                value="{{ request.args.get('q') or '' }}"
-                placeholder="Text included in the experiment"
-                class="form-input-full form-input-blue" />
-          </label>
-
-          <input class="flex-end" type="submit" value="🔍 Search" />
-          <input class="flex-end white-button" type="reset" value="🧹 Clear" />
-        </div>
-
-        <div class="form-row full">
-          <label class="flex-1">
-            <span>By microbial strain:</span>
-            <select
-                tabindex="2"
-                name="strainIds"
-                multiple="multiple"
-                class="strain-select js-strain-select">
-              {% for study_strain in study.strains: %}
-                <option value="{{ study_strain.id }}">{{ study_strain.name }} (NCBI:{{ study_strain.taxon.ncbiId }})</option>
-              {% endfor %}
-            </select>
-          </label>
-
-          <label class="flex-1">
-            <span>By metabolite:</span>
-            <select
-                tabindex="3"
-                name="metaboliteIds"
-                multiple="multiple"
-                class="metabolite-select js-metabolite-select">
-              {% for metabolite in study.metabolites: %}
-                <option value="{{ metabolite.id }}">{{ metabolite.name }} ({{ metabolite.chebiId }})</option>
-              {% endfor %}
-            </select>
-          </label>
-
-          {% if study_model_types: %}
-            <label class="flex-1">
-              <span>With model predictions:</span>
-              <select
-                  name="modelingTypes"
-                  multiple="multiple"
-                  tabindex="4"
-                  class="form-input-blue form-input-full js-modeling-type-select">
-                {% if 'easy_linear' in study_model_types: %}
-                  <option value="easy_linear">"Easy linear" method</option>
-                {% endif %}
-                {% if 'logistic' in study_model_types: %}
-                  <option value="logistic">Logistic model</option>
-                {% endif %}
-                {% if 'baranyi_roberts' in study_model_types: %}
-                  <option value="baranyi_roberts">Baranyi-Roberts model</option>
-                {% endif %}
-
-                {% if study.customModels: %}
-                  {% for m in study.customModels:  %}
-                    <option
-                        {{ "selected" if m.id == selectedCustomModelId }}
-                        value="custom_{{ m.id }}"
-                        data-custom-model-id="{{ m.id }}">
-                      {{ m.name }}
-                    </option>
-                  {% endfor %}
-                {% endif %}
-              </select>
+        <fieldset>
+          <legend class="small">Filter experiments</legend>
+          <div class="form-row small-input-row full">
+            <label class="full">
+              <span>By text:</span>
+              <input
+                  type="text"
+                  name="q"
+                  tabindex="1"
+                  autocomplete="off"
+                  value="{{ request.args.get('q') or '' }}"
+                  placeholder="Text included in the experiment"
+                  class="form-input-full form-input-blue" />
             </label>
-          {% endif %}
-        </div>
+
+            <input class="flex-end" type="submit" value="🔍 Search" />
+            <input class="flex-end white-button" type="reset" value="🧹 Clear" />
+          </div>
+
+          <div class="form-row small-input-row full">
+            {% if study.strains: %}
+              <label class="flex-1">
+                <span>By microbial strain:</span>
+                <select
+                    tabindex="2"
+                    name="strainIds"
+                    multiple="multiple"
+                    class="strain-select js-strain-select">
+                  {% for study_strain in study.strains: %}
+                    <option value="{{ study_strain.id }}">{{ study_strain.name }} (NCBI:{{ study_strain.taxon.ncbiId }})</option>
+                  {% endfor %}
+                </select>
+              </label>
+            {% endif %}
+
+            {% if study.metabolites: %}
+              <label class="flex-1">
+                <span>By metabolite:</span>
+                <select
+                    tabindex="3"
+                    name="metaboliteIds"
+                    multiple="multiple"
+                    class="metabolite-select js-metabolite-select">
+                  {% for metabolite in study.metabolites: %}
+                    <option value="{{ metabolite.id }}">{{ metabolite.name }} ({{ metabolite.chebiId }})</option>
+                  {% endfor %}
+                </select>
+              </label>
+            {% endif %}
+
+            {% if study_model_types: %}
+              <label class="flex-1">
+                <span>With model predictions:</span>
+                <select
+                    name="modelingTypes"
+                    multiple="multiple"
+                    tabindex="4"
+                    class="form-input-blue form-input-full js-modeling-type-select">
+                  {% if 'easy_linear' in study_model_types: %}
+                    <option value="easy_linear">"Easy linear" method</option>
+                  {% endif %}
+                  {% if 'logistic' in study_model_types: %}
+                    <option value="logistic">Logistic model</option>
+                  {% endif %}
+                  {% if 'baranyi_roberts' in study_model_types: %}
+                    <option value="baranyi_roberts">Baranyi-Roberts model</option>
+                  {% endif %}
+
+                  {% if study.customModels: %}
+                    {% for m in study.customModels:  %}
+                      <option
+                          {{ "selected" if m.id == selectedCustomModelId }}
+                          value="custom_{{ m.id }}"
+                          data-custom-model-id="{{ m.id }}">
+                      {{ m.name }}
+                      </option>
+                    {% endfor %}
+                  {% endif %}
+                </select>
+              </label>
+            {% endif %}
+          </div>
+        </fieldset>
       </form>
 
       <div

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -217,6 +217,13 @@
       <div
           data-url="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
           class="js-experiments experiments full">
+        <h2>
+          Loading experiments
+
+          <img
+              class="inline-loader-image loader-image"
+              src="{{ url_for('static', filename="images/loader.svg") }}" />
+        </h2>
       </div>
     </article>
   </div>

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -1,10 +1,7 @@
 {% from 'utils/_dataframe.html' import render_dataframe %}
 {% from 'utils/_time_tag.html' import time_tag %}
-{% from 'utils/_strain_link.html' import render_strain_link %}
 {% from 'utils/_post_button.html' import post_button %}
 {% from 'pages/studies/_experiments_toc.html' import render_experiments_toc %}
-{% from 'pages/experiments/_bioreplicates_list.html' import render_bioreplicates_list %}
-{% from 'pages/perturbations/_perturbation.html' import render_perturbation %}
 {% from 'pages/search/_strains_and_metabolites.html' import render_strains_and_metabolites %}
 
 {% extends '_layout.html' %}
@@ -198,75 +195,16 @@
       {% endif %}
 
       <div class="flex-row">
-        <div class="experiments full">
-          {% for experiment in study.experiments: %}
-            <div class="experiment-container">
-              <h2 id="experiment-{{ experiment.publicId }}">
-                Experiment {{ loop.index }}: {{ experiment.name }}
-              </h2>
+        <div
+            data-url="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
+            class="js-experiments experiments full">
+          <h2>
+            Loading experiments
 
-              {% if experiment.publicId: %}
-                <p class="small">
-                  <strong>Public ID</strong>:
-                  <a href="{{ url_for('experiment_show_page', publicId=experiment.publicId) }}">
-                    {{ experiment.publicId }}
-                  </a>
-                  <br>
-                </p>
-              {% endif %}
-
-              {% if experiment.description: %}
-                {{ experiment.description|format_text }}
-              {% endif %}
-
-              <br>
-
-              <h3>Compartments</h3>
-
-              <ol>
-                {% for compartment in experiment.compartments: %}
-                  <li>
-                    <strong>{{ compartment.name }}</strong>
-
-                    <br>
-
-                    Medium:
-                    {% if compartment.mediumUrl: %}
-                      {{ compartment.mediumUrl|external_link(compartment.mediumName) }}
-                    {% else: %}
-                      {{ compartment.mediumName }}
-                    {% endif %}
-
-                    <br>
-
-                    Properties: {{ compartment.properties_description|safe }}
-                  </li>
-                {% endfor %}
-              </ol>
-
-              <h3>Community: {{ experiment.community.name }}</h3>
-
-              <ol>
-                {% for strain in experiment.community.strains|sort: %}
-                  <li>{{ render_strain_link(strain) }}</li>
-                {% endfor %}
-              </ol>
-
-              {% if experiment.perturbations|length > 0: %}
-                <h3>Perturbations</h3>
-
-                <ol>
-                  {% for perturbation in experiment.perturbations: %}
-                    <li>{{ render_perturbation(perturbation, link=True) }}</li>
-                  {% endfor %}
-                </ol>
-              {% endif %}
-
-              <h3>Biological replicates</h3>
-
-              {{ render_bioreplicates_list(experiment) }}
-            </div>
-          {% endfor %}
+            <img
+                class="inline-loader-image loader-image"
+                src="{{ url_for('static', filename="images/loader.svg") }}" />
+          </h2>
         </div>
 
         <div class="toc-container">

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -195,7 +195,7 @@
 
       <form
           action="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
-          class="simple-form experiment-filter-form margin-top-10 js-search-form">
+          class="simple-form experiment-filter-form margin-top-10 js-filter-form">
         <fieldset>
           <legend class="small">Filter experiments</legend>
           <div class="form-row small-input-row full">

--- a/app/view/templates/pages/studies/show.html
+++ b/app/view/templates/pages/studies/show.html
@@ -1,7 +1,6 @@
 {% from 'utils/_dataframe.html' import render_dataframe %}
 {% from 'utils/_time_tag.html' import time_tag %}
 {% from 'utils/_post_button.html' import post_button %}
-{% from 'pages/studies/_experiments_toc.html' import render_experiments_toc %}
 {% from 'pages/search/_strains_and_metabolites.html' import render_strains_and_metabolites %}
 
 {% extends '_layout.html' %}
@@ -194,22 +193,30 @@
         </div>
       {% endif %}
 
-      <div class="flex-row">
-        <div
-            data-url="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
-            class="js-experiments experiments full">
-          <h2>
-            Loading experiments
+      <form
+          action="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
+          class="simple-form margin-top-10 js-search-form">
+        <div class="form-row full">
+          <label class="full">
+            <span>Filter by text:</span>
+            <input
+                type="text"
+                name="q"
+                tabindex="1"
+                autocomplete="off"
+                value="{{ request.args.get('q') or '' }}"
+                placeholder="Text included in the experiment"
+                class="form-input-full form-input-blue" />
+          </label>
 
-            <img
-                class="inline-loader-image loader-image"
-                src="{{ url_for('static', filename="images/loader.svg") }}" />
-          </h2>
+          <input class="flex-end" type="submit" value="🔍 Search" />
+          <input class="flex-end white-button" type="reset" value="🧹 Clear" />
         </div>
+      </form>
 
-        <div class="toc-container">
-          {{ render_experiments_toc(study.experiments) }}
-        </div>
+      <div
+          data-url="{{ url_for('study_experiments_fragment', publicId=study.publicId) }}"
+          class="js-experiments experiments full">
       </div>
     </article>
   </div>

--- a/initialization/routes.py
+++ b/initialization/routes.py
@@ -83,6 +83,7 @@ def init_routes(app):
     )
 
     app.add_url_rule("/study/<string:publicId>/",                view_func=study_pages.study_show_page)
+    app.add_url_rule("/study/<string:publicId>/experiments",     view_func=study_pages.study_experiments_fragment)
     app.add_url_rule("/study/<string:publicId>.zip",             view_func=study_pages.study_download_data_zip, methods=["POST"])
     app.add_url_rule("/study/<string:publicId>/export/",         view_func=study_pages.study_export_page)
     app.add_url_rule("/study/<string:publicId>/export/preview",  view_func=study_pages.study_export_preview_fragment, methods=["POST"])

--- a/initialization/routes.py
+++ b/initialization/routes.py
@@ -85,13 +85,22 @@ def init_routes(app):
     app.add_url_rule("/study/<string:publicId>/",                view_func=study_pages.study_show_page)
     app.add_url_rule("/study/<string:publicId>/experiments",     view_func=study_pages.study_experiments_fragment)
     app.add_url_rule("/study/<string:publicId>.zip",             view_func=study_pages.study_download_data_zip, methods=["POST"])
-    app.add_url_rule("/study/<string:publicId>/export/",         view_func=study_pages.study_export_page)
-    app.add_url_rule("/study/<string:publicId>/export/preview",  view_func=study_pages.study_export_preview_fragment, methods=["POST"])
     app.add_url_rule("/study/<string:publicId>/manage/",         view_func=study_pages.study_manage_page)
     app.add_url_rule("/study/<string:publicId>/visualize/",      view_func=study_pages.study_visualize_page)
     app.add_url_rule("/study/<string:publicId>/visualize/chart", view_func=study_pages.study_chart_fragment, methods=["POST"])
-    app.add_url_rule("/study/<string:publicId>/reset",           view_func=study_pages.study_reset_action,   methods=["POST"])
+    app.add_url_rule("/study/<string:publicId>/reset",           view_func=study_pages.study_reset_action, methods=["POST"])
     app.add_url_rule("/study/<string:publicId>/history/",        view_func=study_pages.study_history_page)
+
+    app.add_url_rule("/study/<string:publicId>/export/", view_func=study_pages.study_export_page)
+    app.add_url_rule(
+        "/study/<string:publicId>/export/experiments",
+        view_func=study_pages.study_export_experiments_fragment,
+    )
+    app.add_url_rule(
+        "/study/<string:publicId>/export/preview",
+        view_func=study_pages.study_export_preview_fragment,
+        methods=["POST"],
+    )
 
     app.add_url_rule("/modeling/<string:publicId>/",           view_func=modeling_pages.modeling_page)
     app.add_url_rule("/modeling/<string:publicId>/models.csv", view_func=modeling_pages.modeling_params_csv, methods=["POST"])

--- a/tests/model/lib/test_experiment_search.py
+++ b/tests/model/lib/test_experiment_search.py
@@ -1,0 +1,60 @@
+import tests.init  # noqa: F401
+
+import unittest
+
+from app.model.lib.experiment_search import ExperimentSearch
+from tests.database_test import DatabaseTest
+
+
+class TestExperimentSearch(DatabaseTest):
+    def test_text_query(self):
+        s1 = self.create_study()
+        e1 = self.create_experiment(studyId=s1.publicId, name="Foo")
+        e2 = self.create_experiment(studyId=s1.publicId, name="Bar")
+        e3 = self.create_experiment(studyId=s1.publicId, name="FooBar")
+        e4 = self.create_experiment(studyId=s1.publicId, name="Test", description="Bar")
+
+        s2 = self.create_study()
+        e5 = self.create_experiment(studyId=s2.publicId, name="Foo")
+
+        search = ExperimentSearch(self.db_session, study=s1, query="foo")
+        self._assertEqualPublicIds(search.fetch_results(), [e1, e3])
+
+        search = ExperimentSearch(self.db_session, study=s2, query="foo")
+        self._assertEqualPublicIds(search.fetch_results(), [e5])
+
+        search = ExperimentSearch(self.db_session, study=s1, query="BAR")
+        self._assertEqualPublicIds(search.fetch_results(), [e2, e3, e4])
+
+        search = ExperimentSearch(self.db_session, study=s1, query="foobar")
+        self._assertEqualPublicIds(search.fetch_results(), [e3])
+
+    def test_public_id_query(self):
+        s = self.create_study()
+
+        e1  = self.create_experiment(publicId="EMGDB000000001", studyId=s.publicId)
+        e2  = self.create_experiment(publicId="EMGDB000000002", studyId=s.publicId)
+        e30 = self.create_experiment(publicId="EMGDB000000030", studyId=s.publicId)
+
+        search = ExperimentSearch(self.db_session, study=s, query="EMGDB000000001")
+        self._assertEqualPublicIds(search.fetch_results(), [e1])
+
+        search = ExperimentSearch(self.db_session, study=s, query="emgdb2")
+        self._assertEqualPublicIds(search.fetch_results(), [e2])
+
+        search = ExperimentSearch(self.db_session, study=s, query="EMGDB30")
+        self._assertEqualPublicIds(search.fetch_results(), [e30])
+
+        search = ExperimentSearch(self.db_session, study=s, query="emgdb000000000000000001")
+        self._assertEqualPublicIds(search.fetch_results(), [e1])
+
+    def _assertEqualPublicIds(self, list1, list2):
+        get_public_id = lambda s: s.publicId
+        self.assertEqual(
+            list(map(get_public_id, list1)),
+            list(map(get_public_id, list2)),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/model/lib/test_experiment_search.py
+++ b/tests/model/lib/test_experiment_search.py
@@ -108,6 +108,33 @@ class TestExperimentSearch(DatabaseTest):
         )
         self._assertEqualPublicIds(search.fetch_results(), [e2, e3])
 
+    def test_modeling_types(self):
+        s = self.create_study()
+
+        e1 = self.create_experiment(studyId=s.publicId)
+        b1 = self.create_bioreplicate(experimentId=e1.publicId)
+        mc1 = self.create_measurement_context(bioreplicateId=b1.id)
+        mr1 = self.create_modeling_result(type='baranyi_roberts', measurementContextId=mc1.id)
+        mr2 = self.create_modeling_result(type='custom_1', measurementContextId=mc1.id)
+
+        e2 = self.create_experiment(studyId=s.publicId)
+        b2 = self.create_bioreplicate(experimentId=e2.publicId)
+        mc2 = self.create_measurement_context(bioreplicateId=b2.id)
+        mr3 = self.create_modeling_result(type='baranyi_roberts', measurementContextId=mc2.id)
+        mr4 = self.create_modeling_result(type='custom_2', measurementContextId=mc2.id)
+
+        search = ExperimentSearch(self.db_session, study=s, modeling_types=['baranyi_roberts'])
+        self._assertEqualPublicIds(search.fetch_results(), [e1, e2])
+
+        search = ExperimentSearch(self.db_session, study=s, modeling_types=['custom_1'])
+        self._assertEqualPublicIds(search.fetch_results(), [e1])
+
+        search = ExperimentSearch(self.db_session, study=s, modeling_types=['custom_2'])
+        self._assertEqualPublicIds(search.fetch_results(), [e2])
+
+        search = ExperimentSearch(self.db_session, study=s, modeling_types=['custom_1', 'custom_2'])
+        self._assertEqualPublicIds(search.fetch_results(), [e1, e2])
+
     def _assertEqualPublicIds(self, list1, list2):
         get_public_id = lambda s: s.publicId
         self.assertEqual(

--- a/tests/model/lib/test_experiment_search.py
+++ b/tests/model/lib/test_experiment_search.py
@@ -48,6 +48,66 @@ class TestExperimentSearch(DatabaseTest):
         search = ExperimentSearch(self.db_session, study=s, query="emgdb000000000000000001")
         self._assertEqualPublicIds(search.fetch_results(), [e1])
 
+    def test_strains_or_metabolites(self):
+        s = self.create_study()
+
+        strain1 = self.create_study_strain(studyId=s.publicId)
+        strain2 = self.create_study_strain(studyId=s.publicId)
+        metabolite = self.create_study_metabolite(studyId=s.publicId)
+
+        e1 = self.create_experiment(studyId=s.publicId)
+        b1 = self.create_bioreplicate(experimentId=e1.publicId)
+        mc1 = self.create_measurement_context(
+            bioreplicateId=b1.id,
+            subjectId=strain1.id,
+            subjectType='strain',
+        )
+
+        e2 = self.create_experiment(studyId=s.publicId)
+        b2 = self.create_bioreplicate(experimentId=e2.publicId)
+        b3 = self.create_bioreplicate(experimentId=e2.publicId)
+        mc2 = self.create_measurement_context(
+            bioreplicateId=b2.id,
+            subjectId=strain1.id,
+            subjectType='strain',
+        )
+        mc3 = self.create_measurement_context(
+            bioreplicateId=b3.id,
+            subjectId=strain2.id,
+            subjectType='strain',
+        )
+        mc4 = self.create_measurement_context(
+            bioreplicateId=b3.id,
+            subjectId=metabolite.id,
+            subjectType='metabolite',
+        )
+
+        e3 = self.create_experiment(studyId=s.publicId)
+        b4 = self.create_bioreplicate(experimentId=e3.publicId)
+        mc5 = self.create_measurement_context(
+            bioreplicateId=b4.id,
+            subjectId=metabolite.id,
+            subjectType='metabolite',
+        )
+
+        search = ExperimentSearch(self.db_session, study=s, strain_ids=[strain1.id])
+        self._assertEqualPublicIds(search.fetch_results(), [e1, e2])
+
+        search = ExperimentSearch(self.db_session, study=s, strain_ids=[strain2.id])
+        self._assertEqualPublicIds(search.fetch_results(), [e2])
+
+        search = ExperimentSearch(self.db_session, study=s, metabolite_ids=[metabolite.id])
+        self._assertEqualPublicIds(search.fetch_results(), [e2, e3])
+
+        # Searching for both finds experiments with either one:
+        search = ExperimentSearch(
+            self.db_session,
+            study=s,
+            strain_ids=[strain2.id],
+            metabolite_ids=[metabolite.id],
+        )
+        self._assertEqualPublicIds(search.fetch_results(), [e2, e3])
+
     def _assertEqualPublicIds(self, list1, list2):
         get_public_id = lambda s: s.publicId
         self.assertEqual(

--- a/tests/model/lib/test_experiment_search.py
+++ b/tests/model/lib/test_experiment_search.py
@@ -48,6 +48,32 @@ class TestExperimentSearch(DatabaseTest):
         search = ExperimentSearch(self.db_session, study=s, query="emgdb000000000000000001")
         self._assertEqualPublicIds(search.fetch_results(), [e1])
 
+    def test_strains_through_community(self):
+        s = self.create_study()
+
+        strain1 = self.create_study_strain(studyId=s.publicId)
+        strain2 = self.create_study_strain(studyId=s.publicId)
+
+        c1 = self.create_community(studyId=s.publicId)
+        self.create_community_strain(strainId=strain1.id, communityId=c1.id)
+
+        c2 = self.create_community(studyId=s.publicId)
+        self.create_community_strain(strainId=strain2.id, communityId=c2.id)
+
+        c12 = self.create_community(studyId=s.publicId)
+        self.create_community_strain(strainId=strain1.id, communityId=c12.id)
+        self.create_community_strain(strainId=strain2.id, communityId=c12.id)
+
+        e1 = self.create_experiment(studyId=s.publicId, communityId=c1.id)
+        e2 = self.create_experiment(studyId=s.publicId, communityId=c2.id)
+        e3 = self.create_experiment(studyId=s.publicId, communityId=c12.id)
+
+        search = ExperimentSearch(self.db_session, study=s, strain_ids=[strain1.id])
+        self._assertEqualPublicIds(search.fetch_results(), [e1, e3])
+
+        search = ExperimentSearch(self.db_session, study=s, strain_ids=[strain2.id])
+        self._assertEqualPublicIds(search.fetch_results(), [e2, e3])
+
     def test_strains_or_metabolites(self):
         s = self.create_study()
 

--- a/tests/model/lib/test_study_search.py
+++ b/tests/model/lib/test_study_search.py
@@ -6,6 +6,7 @@ from datetime import datetime, UTC
 from app.model.lib.study_search import StudySearch
 from tests.database_test import DatabaseTest
 
+
 class TestStudySearch(DatabaseTest):
     def test_user_permissions(self):
         user1 = self.create_user()
@@ -103,7 +104,7 @@ class TestStudySearch(DatabaseTest):
         self.create_study_strain(studyId=s3.publicId, ncbiId=blautia.ncbiId)
 
         # No connected strains, will not be returned:
-        s4 = self.create_study()
+        _s4 = self.create_study()
 
         search = StudySearch(self.db_session, user=admin, ncbiIds=[roseburia.ncbiId])
         self._assertEqualPublicIds(search.fetch_results(), [s2, s1])
@@ -141,7 +142,7 @@ class TestStudySearch(DatabaseTest):
         self.create_study_metabolite(studyId=s3.publicId, chebiId=trehalose.chebiId)
 
         # No connected metabolites, will not be returned:
-        s4 = self.create_study()
+        _s4 = self.create_study()
 
         search = StudySearch(self.db_session, user=admin, chebiIds=[glucose.chebiId])
         self._assertEqualPublicIds(search.fetch_results(), [s2, s1])


### PR DESCRIPTION
This PR adds a filter on the experiments page and the export page to narrow down a set of experiments to scroll through. This can be useful particularly for large studies if you know what strain or text you're searching for. In theory, you could just Ctrl+F on the page, but I think this is nicer, and in the future, we can have pagination on this area.

It's not perfect, since if the results are slow, there can be race conditions as you type -- the first result can arrive after the second and overwrite it. But this should be fine for now and people can always submit the search again if they see the result is not quite right.

In a future development when we store media ingredients in the database, we could add media filters here as well, which would be particularly useful for some studies.

| Filter by text | Filter by text+strain | Filter export page |
| --- | --- | --- |
| <img width="1445" height="600" alt="screenshot-2026-07-30-105512" src="https://github.com/user-attachments/assets/9315e0ed-9292-42e8-b476-b2f49ac27d33" /> | <img width="1444" height="873" alt="screenshot-2026-07-30-105528" src="https://github.com/user-attachments/assets/a1277e08-cac0-4f2e-9f4b-a41416ee91b8" /> | <img width="1440" height="1080" alt="screenshot-2026-07-30-105632" src="https://github.com/user-attachments/assets/9ed92c85-167c-490c-8346-de0d08468cda" /> |
