### PR TITLE
Post-submission tasks, automatic growth rates calculation

### DIFF
--- a/app/model/lib/average_measurements.py
+++ b/app/model/lib/average_measurements.py
@@ -1,0 +1,171 @@
+import itertools
+import sqlalchemy as sql
+
+from app.model.orm import (
+    Bioreplicate,
+    Measurement,
+    MeasurementContext,
+)
+
+
+def create_average_measurements(db_session, study, experiment):
+    """
+    Triggered by a background job in app.model.tasks.submissions
+    """
+    bioreplicate_ids = [b.id for b in experiment.bioreplicates if not b.calculationType]
+
+    # The averaged measurements will be parented by a custom-generated bioreplicate:
+    average_bioreplicate = Bioreplicate(
+        name=f"Average({experiment.name})",
+        calculationType='average',
+        experiment=experiment,
+    )
+    db_session.add(average_bioreplicate)
+
+    has_measurements = False
+
+    for technique in study.measurementTechniques:
+        for compartment in experiment.compartments:
+            # We'll average values separately over techniques and compartments:
+            measurement_contexts = db_session.scalars(
+                sql.select(MeasurementContext)
+                .distinct()
+                .join(Measurement)
+                .where(
+                    MeasurementContext.compartmentId == compartment.id,
+                    MeasurementContext.bioreplicateId.in_(bioreplicate_ids),
+                    MeasurementContext.techniqueId == technique.id,
+                    Measurement.value.is_not(None),
+                )
+                .order_by(MeasurementContext.subjectType, MeasurementContext.subjectId)
+            ).all()
+
+            # If there is a single context for this cluster of measurements, there is nothing to average:
+            if len(measurement_contexts) <= 1:
+                continue
+
+            # Only average the shared time points, if any
+            common_time_points = None
+            max_time_point_count = 0
+
+            for measurement_context in measurement_contexts:
+                time_points = [m.timeInSeconds for m in measurement_context.measurements]
+                if len(time_points) > max_time_point_count:
+                    max_time_point_count = len(time_points)
+
+                if common_time_points is None:
+                    common_time_points = frozenset(time_points)
+                else:
+                    common_time_points = common_time_points.intersection(time_points)
+
+            if common_time_points is None or len(common_time_points) <= (max_time_point_count // 2):
+                continue
+
+            if technique.subjectType == 'bioreplicate':
+                # A single context for a group of bioreplicates
+                _create_average_measurement_context(
+                    db_session,
+                    common_time_points=common_time_points,
+                    parent_records=(study, technique, compartment),
+                    measurement_contexts=measurement_contexts,
+                    average_bioreplicate=average_bioreplicate,
+                    subject_id=average_bioreplicate.id,
+                    subject_type='bioreplicate',
+                    subject_name=average_bioreplicate.name,
+                    subject_external_id=None,
+                )
+                has_measurements = True
+            else:
+                grouped_contexts = itertools.groupby(
+                    measurement_contexts,
+                    lambda mc: (mc.subjectId, mc.subjectType, mc.subjectName, mc.subjectExternalId),
+                )
+
+                for key, subject_contexts in grouped_contexts:
+                    subject_contexts = list(subject_contexts)
+                    (
+                        subject_id,
+                        subject_type,
+                        subject_name,
+                        subject_external_id,
+                    ) = key
+
+                    # If there is a single context for this cluster of
+                    # measurements, there is nothing to average:
+                    if len(subject_contexts) <= 1:
+                        continue
+
+                    # One context for each subject:
+                    _create_average_measurement_context(
+                        db_session,
+                        common_time_points=common_time_points,
+                        parent_records=(study, technique, compartment),
+                        measurement_contexts=list(subject_contexts),
+                        average_bioreplicate=average_bioreplicate,
+                        subject_id=subject_id,
+                        subject_type=subject_type,
+                        subject_name=subject_name,
+                        subject_external_id=subject_external_id,
+                    )
+                    has_measurements = True
+
+    if not has_measurements:
+        db_session.delete(average_bioreplicate)
+
+
+def _create_average_measurement_context(
+    db_session,
+    common_time_points,
+    parent_records,
+    measurement_contexts,
+    average_bioreplicate,
+    subject_id,
+    subject_type,
+    subject_name,
+    subject_external_id=None,
+):
+    (study, technique, compartment) = parent_records
+
+    # Collect average measurement values for the given contexts:
+    measurement_rows = db_session.execute(
+        sql.select(
+            Measurement.timeInSeconds,
+            sql.func.avg(Measurement.value),
+            sql.func.std(Measurement.value),
+        )
+        .where(
+            Measurement.contextId.in_([mc.id for mc in measurement_contexts]),
+            Measurement.timeInSeconds.in_(common_time_points),
+        )
+        .group_by(Measurement.timeInSeconds)
+        .order_by(Measurement.timeInSeconds)
+    ).all()
+
+    if len(measurement_rows) == 0:
+        # We do not want to create unnecessary contexts
+        return
+
+    # Create a parent context for the individual measurements:
+    average_context = MeasurementContext(
+        study=study,
+        bioreplicate=average_bioreplicate,
+        compartment=compartment,
+        subjectId=subject_id,
+        subjectType=subject_type,
+        subjectName=subject_name,
+        subjectExternalId=subject_external_id,
+        technique=technique,
+        calculationType='average',
+    )
+    db_session.add(average_context)
+
+    # Create individual measurements
+    for (t, value, std) in measurement_rows:
+        measurement = Measurement(
+            timeInSeconds=t,
+            value=value,
+            std=std,
+            context=average_context,
+            study=study,
+        )
+        db_session.add(measurement)

--- a/app/model/lib/batch_growth_rates.py
+++ b/app/model/lib/batch_growth_rates.py
@@ -3,14 +3,19 @@ import tempfile
 from app.model.lib.r_script import RScript
 
 
-def calculate_growth_rate(db_session, experiment, measurement_context):
+def growth_can_be_estimated(experiment, measurement_context):
     if experiment.cultivationMode != 'batch':
         return False
-
     if measurement_context.subjectType not in ('bioreplicate', 'strain'):
         return False
-
     if measurement_context.technique.type == 'ph':
+        return False
+
+    return True
+
+
+def calculate_growth_rate(db_session, experiment, measurement_context):
+    if not growth_can_be_estimated(experiment, measurement_context):
         return False
 
     with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/app/model/lib/study_growth_rates.py
+++ b/app/model/lib/study_growth_rates.py
@@ -1,0 +1,48 @@
+import tempfile
+
+from app.model.lib.r_script import RScript
+
+
+def calculate_growth_rate(db_session, experiment, measurement_context):
+    if experiment.cultivationMode != 'batch':
+        return False
+
+    if measurement_context.subjectType not in ('bioreplicate', 'strain'):
+        return False
+
+    if measurement_context.technique.type == 'ph':
+        return False
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        data = measurement_context.get_df(db_session)
+        # We don't need error columns for modeling:
+        data = data[["time", "value"]]
+        # Remove rows with NA values, if any
+        data = data.dropna()
+
+        if data.shape[0] < 6:
+            return False
+
+        try:
+            rscript = RScript(root_path=tmp_dir_name)
+            rscript.write_csv('input.csv', data)
+            rscript.write_json('input.json', {'pointCount': 5})
+
+            rscript.run('scripts/modeling/easy_linear.R')
+
+            coefficients = rscript.read_key_value_json(
+                'coefficients.json',
+                key_name="_row",
+                value_name="coefficients",
+            )
+
+            if coefficients is None:
+                return False
+
+            measurement_context.growthRate = coefficients['mumax']
+            db_session.add(measurement_context)
+            db_session.commit()
+
+            return True
+        except Exception as e:
+            return False

--- a/app/model/lib/submission_process.py
+++ b/app/model/lib/submission_process.py
@@ -27,7 +27,7 @@ from app.model.orm import (
 )
 from app.model.lib.util import group_by_unique_name, is_non_negative_float, find_duplicates
 from app.model.lib.conversion import convert_time
-from app.model.tasks.submissions import export_submission_data
+from app.model.tasks.submissions import run_post_submission_jobs
 
 
 def persist_submission_to_database(submission_form):
@@ -58,17 +58,13 @@ def persist_submission_to_database(submission_form):
 
         _save_measurements(db_trans_session, study, submission_form)
 
-        for experiment in study.experiments:
-            _create_average_measurements(db_trans_session, study, experiment)
-
         _finalize_submission(db_trans_session, submission_form, study, project)
 
         db_trans_session.commit()
 
-        if study.isPublished:
-            export_submission_data.delay(submission.id)
+    run_post_submission_jobs.delay(submission.id)
 
-        return []
+    return []
 
 
 # TODO (2025-05-11) Test (separate read_data_file, operate on dfs)
@@ -187,6 +183,111 @@ def validate_data_file(submission_form, data_file=None):
                 errors.append(f"{sheet_name}: Time points are not unique for bioreplicate {b}, compartment {c}: {duplicates_description}")
 
     return errors
+
+
+def create_average_measurements(db_session, study, experiment):
+    """
+    Triggered by a background job in app.model.tasks.submissions
+    """
+    bioreplicate_ids = [b.id for b in experiment.bioreplicates if not b.calculationType]
+
+    # The averaged measurements will be parented by a custom-generated bioreplicate:
+    average_bioreplicate = Bioreplicate(
+        name=f"Average({experiment.name})",
+        calculationType='average',
+        experiment=experiment,
+    )
+    db_session.add(average_bioreplicate)
+
+    has_measurements = False
+
+    for technique in study.measurementTechniques:
+        for compartment in experiment.compartments:
+            # We'll average values separately over techniques and compartments:
+            measurement_contexts = db_session.scalars(
+                sql.select(MeasurementContext)
+                .distinct()
+                .join(Measurement)
+                .where(
+                    MeasurementContext.compartmentId == compartment.id,
+                    MeasurementContext.bioreplicateId.in_(bioreplicate_ids),
+                    MeasurementContext.techniqueId == technique.id,
+                    Measurement.value.is_not(None),
+                )
+                .order_by(MeasurementContext.subjectType, MeasurementContext.subjectId)
+            ).all()
+
+            # If there is a single context for this cluster of measurements, there is nothing to average:
+            if len(measurement_contexts) <= 1:
+                continue
+
+            # Only average the shared time points, if any
+            common_time_points = None
+            max_time_point_count = 0
+
+            for measurement_context in measurement_contexts:
+                time_points = [m.timeInSeconds for m in measurement_context.measurements]
+                if len(time_points) > max_time_point_count:
+                    max_time_point_count = len(time_points)
+
+                if common_time_points is None:
+                    common_time_points = frozenset(time_points)
+                else:
+                    common_time_points = common_time_points.intersection(time_points)
+
+            if common_time_points is None or len(common_time_points) <= (max_time_point_count // 2):
+                continue
+
+            if technique.subjectType == 'bioreplicate':
+                # A single context for a group of bioreplicates
+                _create_average_measurement_context(
+                    db_session,
+                    common_time_points=common_time_points,
+                    parent_records=(study, technique, compartment),
+                    measurement_contexts=measurement_contexts,
+                    average_bioreplicate=average_bioreplicate,
+                    subject_id=average_bioreplicate.id,
+                    subject_type='bioreplicate',
+                    subject_name=average_bioreplicate.name,
+                    subject_external_id=None,
+                )
+                has_measurements = True
+            else:
+                grouped_contexts = itertools.groupby(
+                    measurement_contexts,
+                    lambda mc: (mc.subjectId, mc.subjectType, mc.subjectName, mc.subjectExternalId),
+                )
+
+                for key, subject_contexts in grouped_contexts:
+                    subject_contexts = list(subject_contexts)
+                    (
+                        subject_id,
+                        subject_type,
+                        subject_name,
+                        subject_external_id,
+                    ) = key
+
+                    # If there is a single context for this cluster of
+                    # measurements, there is nothing to average:
+                    if len(subject_contexts) <= 1:
+                        continue
+
+                    # One context for each subject:
+                    _create_average_measurement_context(
+                        db_session,
+                        common_time_points=common_time_points,
+                        parent_records=(study, technique, compartment),
+                        measurement_contexts=list(subject_contexts),
+                        average_bioreplicate=average_bioreplicate,
+                        subject_id=subject_id,
+                        subject_type=subject_type,
+                        subject_name=subject_name,
+                        subject_external_id=subject_external_id,
+                    )
+                    has_measurements = True
+
+    if not has_measurements:
+        db_session.delete(average_bioreplicate)
 
 
 def _save_study(db_session, submission_form, user_uuid=None):
@@ -456,108 +557,6 @@ def _save_measurements(db_session, study, submission_form):
 
     for _, df in sheets.items():
         Measurement.insert_from_csv_string(db_session, study, df.to_csv(index=False))
-
-
-def _create_average_measurements(db_session, study, experiment):
-    bioreplicate_ids = [b.id for b in experiment.bioreplicates if not b.calculationType]
-
-    # The averaged measurements will be parented by a custom-generated bioreplicate:
-    average_bioreplicate = Bioreplicate(
-        name=f"Average({experiment.name})",
-        calculationType='average',
-        experiment=experiment,
-    )
-    db_session.add(average_bioreplicate)
-
-    has_measurements = False
-
-    for technique in study.measurementTechniques:
-        for compartment in experiment.compartments:
-            # We'll average values separately over techniques and compartments:
-            measurement_contexts = db_session.scalars(
-                sql.select(MeasurementContext)
-                .distinct()
-                .join(Measurement)
-                .where(
-                    MeasurementContext.compartmentId == compartment.id,
-                    MeasurementContext.bioreplicateId.in_(bioreplicate_ids),
-                    MeasurementContext.techniqueId == technique.id,
-                    Measurement.value.is_not(None),
-                )
-                .order_by(MeasurementContext.subjectType, MeasurementContext.subjectId)
-            ).all()
-
-            # If there is a single context for this cluster of measurements, there is nothing to average:
-            if len(measurement_contexts) <= 1:
-                continue
-
-            # Only average the shared time points, if any
-            common_time_points = None
-            max_time_point_count = 0
-
-            for measurement_context in measurement_contexts:
-                time_points = [m.timeInSeconds for m in measurement_context.measurements]
-                if len(time_points) > max_time_point_count:
-                    max_time_point_count = len(time_points)
-
-                if common_time_points is None:
-                    common_time_points = frozenset(time_points)
-                else:
-                    common_time_points = common_time_points.intersection(time_points)
-
-            if common_time_points is None or len(common_time_points) <= (max_time_point_count // 2):
-                continue
-
-            if technique.subjectType == 'bioreplicate':
-                # A single context for a group of bioreplicates
-                _create_average_measurement_context(
-                    db_session,
-                    common_time_points=common_time_points,
-                    parent_records=(study, technique, compartment),
-                    measurement_contexts=measurement_contexts,
-                    average_bioreplicate=average_bioreplicate,
-                    subject_id=average_bioreplicate.id,
-                    subject_type='bioreplicate',
-                    subject_name=average_bioreplicate.name,
-                    subject_external_id=None,
-                )
-                has_measurements = True
-            else:
-                grouped_contexts = itertools.groupby(
-                    measurement_contexts,
-                    lambda mc: (mc.subjectId, mc.subjectType, mc.subjectName, mc.subjectExternalId),
-                )
-
-                for key, subject_contexts in grouped_contexts:
-                    subject_contexts = list(subject_contexts)
-                    (
-                        subject_id,
-                        subject_type,
-                        subject_name,
-                        subject_external_id,
-                    ) = key
-
-                    # If there is a single context for this cluster of
-                    # measurements, there is nothing to average:
-                    if len(subject_contexts) <= 1:
-                        continue
-
-                    # One context for each subject:
-                    _create_average_measurement_context(
-                        db_session,
-                        common_time_points=common_time_points,
-                        parent_records=(study, technique, compartment),
-                        measurement_contexts=list(subject_contexts),
-                        average_bioreplicate=average_bioreplicate,
-                        subject_id=subject_id,
-                        subject_type=subject_type,
-                        subject_name=subject_name,
-                        subject_external_id=subject_external_id,
-                    )
-                    has_measurements = True
-
-    if not has_measurements:
-        db_session.delete(average_bioreplicate)
 
 
 def _create_average_measurement_context(

--- a/app/model/lib/submission_process.py
+++ b/app/model/lib/submission_process.py
@@ -5,6 +5,7 @@ from db import get_session, get_transaction
 
 import pandas as pd
 import sqlalchemy as sql
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.model.orm import (
     Bioreplicate,
@@ -449,7 +450,6 @@ def _save_measurements(db_session, study, submission_form):
 
     for _, df in sheets.items():
         Measurement.insert_from_csv_string(db_session, study, df.to_csv(index=False))
-
 
 
 def _finalize_submission(db_session, submission_form, study, project):

--- a/app/model/lib/submission_process.py
+++ b/app/model/lib/submission_process.py
@@ -1,6 +1,5 @@
 import io
 import copy
-import itertools
 from datetime import datetime, timedelta, time, UTC
 from db import get_session, get_transaction
 
@@ -57,7 +56,6 @@ def persist_submission_to_database(submission_form):
         db_trans_session.flush()
 
         _save_measurements(db_trans_session, study, submission_form)
-
         _finalize_submission(db_trans_session, submission_form, study, project)
 
         db_trans_session.commit()
@@ -183,112 +181,6 @@ def validate_data_file(submission_form, data_file=None):
                 errors.append(f"{sheet_name}: Time points are not unique for bioreplicate {b}, compartment {c}: {duplicates_description}")
 
     return errors
-
-
-def create_average_measurements(db_session, study, experiment):
-    """
-    Triggered by a background job in app.model.tasks.submissions
-    """
-    bioreplicate_ids = [b.id for b in experiment.bioreplicates if not b.calculationType]
-
-    # The averaged measurements will be parented by a custom-generated bioreplicate:
-    average_bioreplicate = Bioreplicate(
-        name=f"Average({experiment.name})",
-        calculationType='average',
-        experiment=experiment,
-    )
-    db_session.add(average_bioreplicate)
-
-    has_measurements = False
-
-    for technique in study.measurementTechniques:
-        for compartment in experiment.compartments:
-            # We'll average values separately over techniques and compartments:
-            measurement_contexts = db_session.scalars(
-                sql.select(MeasurementContext)
-                .distinct()
-                .join(Measurement)
-                .where(
-                    MeasurementContext.compartmentId == compartment.id,
-                    MeasurementContext.bioreplicateId.in_(bioreplicate_ids),
-                    MeasurementContext.techniqueId == technique.id,
-                    Measurement.value.is_not(None),
-                )
-                .order_by(MeasurementContext.subjectType, MeasurementContext.subjectId)
-            ).all()
-
-            # If there is a single context for this cluster of measurements, there is nothing to average:
-            if len(measurement_contexts) <= 1:
-                continue
-
-            # Only average the shared time points, if any
-            common_time_points = None
-            max_time_point_count = 0
-
-            for measurement_context in measurement_contexts:
-                time_points = [m.timeInSeconds for m in measurement_context.measurements]
-                if len(time_points) > max_time_point_count:
-                    max_time_point_count = len(time_points)
-
-                if common_time_points is None:
-                    common_time_points = frozenset(time_points)
-                else:
-                    common_time_points = common_time_points.intersection(time_points)
-
-            if common_time_points is None or len(common_time_points) <= (max_time_point_count // 2):
-                continue
-
-            if technique.subjectType == 'bioreplicate':
-                # A single context for a group of bioreplicates
-                _create_average_measurement_context(
-                    db_session,
-                    common_time_points=common_time_points,
-                    parent_records=(study, technique, compartment),
-                    measurement_contexts=measurement_contexts,
-                    average_bioreplicate=average_bioreplicate,
-                    subject_id=average_bioreplicate.id,
-                    subject_type='bioreplicate',
-                    subject_name=average_bioreplicate.name,
-                    subject_external_id=None,
-                )
-                has_measurements = True
-            else:
-                grouped_contexts = itertools.groupby(
-                    measurement_contexts,
-                    lambda mc: (mc.subjectId, mc.subjectType, mc.subjectName, mc.subjectExternalId),
-                )
-
-                for key, subject_contexts in grouped_contexts:
-                    subject_contexts = list(subject_contexts)
-                    (
-                        subject_id,
-                        subject_type,
-                        subject_name,
-                        subject_external_id,
-                    ) = key
-
-                    # If there is a single context for this cluster of
-                    # measurements, there is nothing to average:
-                    if len(subject_contexts) <= 1:
-                        continue
-
-                    # One context for each subject:
-                    _create_average_measurement_context(
-                        db_session,
-                        common_time_points=common_time_points,
-                        parent_records=(study, technique, compartment),
-                        measurement_contexts=list(subject_contexts),
-                        average_bioreplicate=average_bioreplicate,
-                        subject_id=subject_id,
-                        subject_type=subject_type,
-                        subject_name=subject_name,
-                        subject_external_id=subject_external_id,
-                    )
-                    has_measurements = True
-
-    if not has_measurements:
-        db_session.delete(average_bioreplicate)
-
 
 def _save_study(db_session, submission_form, user_uuid=None):
     submission = submission_form.submission
@@ -558,63 +450,6 @@ def _save_measurements(db_session, study, submission_form):
     for _, df in sheets.items():
         Measurement.insert_from_csv_string(db_session, study, df.to_csv(index=False))
 
-
-def _create_average_measurement_context(
-    db_session,
-    common_time_points,
-    parent_records,
-    measurement_contexts,
-    average_bioreplicate,
-    subject_id,
-    subject_type,
-    subject_name,
-    subject_external_id=None,
-):
-    (study, technique, compartment) = parent_records
-
-    # Collect average measurement values for the given contexts:
-    measurement_rows = db_session.execute(
-        sql.select(
-            Measurement.timeInSeconds,
-            sql.func.avg(Measurement.value),
-            sql.func.std(Measurement.value),
-        )
-        .where(
-            Measurement.contextId.in_([mc.id for mc in measurement_contexts]),
-            Measurement.timeInSeconds.in_(common_time_points),
-        )
-        .group_by(Measurement.timeInSeconds)
-        .order_by(Measurement.timeInSeconds)
-    ).all()
-
-    if len(measurement_rows) == 0:
-        # We do not want to create unnecessary contexts
-        return
-
-    # Create a parent context for the individual measurements:
-    average_context = MeasurementContext(
-        study=study,
-        bioreplicate=average_bioreplicate,
-        compartment=compartment,
-        subjectId=subject_id,
-        subjectType=subject_type,
-        subjectName=subject_name,
-        subjectExternalId=subject_external_id,
-        technique=technique,
-        calculationType='average',
-    )
-    db_session.add(average_context)
-
-    # Create individual measurements
-    for (t, value, std) in measurement_rows:
-        measurement = Measurement(
-            timeInSeconds=t,
-            value=value,
-            std=std,
-            context=average_context,
-            study=study,
-        )
-        db_session.add(measurement)
 
 
 def _finalize_submission(db_session, submission_form, study, project):

--- a/app/model/orm/experiment.py
+++ b/app/model/orm/experiment.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import List, Literal
 
 import sqlalchemy as sql
 from sqlalchemy.orm import (
@@ -43,7 +43,12 @@ class Experiment(OrmBase):
     studyId: Mapped[str] = mapped_column(sql.ForeignKey('Studies.publicId'), nullable=False)
     study: Mapped['Study'] = relationship(back_populates='experiments')
 
-    cultivationMode: Mapped[str] = mapped_column(sql.String(50))
+    cultivationMode: Mapped[Literal[
+        'batch',
+        'fed-batch',
+        'chemostat',
+        'other',
+    ]] = mapped_column(sql.String(50))
 
     experimentCompartments: Mapped[List['ExperimentCompartment']] = relationship(
         back_populates='experiment',

--- a/app/model/orm/measurement_context.py
+++ b/app/model/orm/measurement_context.py
@@ -1,4 +1,5 @@
 from typing import List
+from decimal import Decimal
 
 import sqlalchemy as sql
 from sqlalchemy.orm import (
@@ -66,6 +67,8 @@ class MeasurementContext(OrmBase):
         subjectType,
         ('bioreplicate', 'strain', 'metabolite'),
     ), deferred=True)
+
+    growthRate: Mapped[Decimal] = mapped_column(sql.Numeric(20, 2), nullable=True)
 
     @property
     def readyModelingResults(self):

--- a/app/model/orm/submission.py
+++ b/app/model/orm/submission.py
@@ -62,6 +62,8 @@ class Submission(OrmBase):
 
     changelogText: Mapped[sql.String] = mapped_column(sql.String, nullable=True)
 
+    jobStatuses: Mapped[sql.JSON] = mapped_column(sql.JSON, nullable=False)
+
     @hybrid_property
     def isPublished(self):
         return self.publishedAt != None

--- a/app/model/tasks/submissions.py
+++ b/app/model/tasks/submissions.py
@@ -6,6 +6,7 @@ from celery.utils.log import get_task_logger
 from db import FLASK_DB
 from app.model.orm import Submission, Study
 from app.model.lib.average_measurements import create_average_measurements
+from app.model.lib.study_growth_rates import calculate_growth_rate
 
 _LOGGER = get_task_logger(__name__)
 
@@ -23,12 +24,16 @@ def run_post_submission_jobs(submission_id):
 
         submission.jobStatuses['calculateAverages'] = 'ready'
         flag_modified(submission, 'jobStatuses')
-
         db_session.commit()
 
     if submission.jobStatuses.get('calculateGrowthrates') == 'pending':
-        # TODO (2026-08-02)
-        pass
+        for experiment in study.experiments:
+            for measurement_context in experiment.measurementContexts:
+                calculate_growth_rate(db_session, experiment, measurement_context)
+
+        submission.jobStatuses['calculateGrowthrates'] = 'ready'
+        flag_modified(submission, 'jobStatuses')
+        db_session.commit()
 
     if study.isPublished:
         _export_submission_data(db_session, submission_id)

--- a/app/model/tasks/submissions.py
+++ b/app/model/tasks/submissions.py
@@ -9,6 +9,23 @@ _LOGGER = get_task_logger(__name__)
 
 
 @shared_task
+def run_post_submission_jobs(submission_id):
+    from app.model.lib.submission_process import create_average_measurements
+
+    db_session = FLASK_DB.session
+
+    submission = db_session.get(Submission, submission_id)
+    study = submission.study
+
+    for experiment in study.experiments:
+        create_average_measurements(db_session, study, experiment)
+    db_session.commit()
+
+    if study.isPublished:
+        _export_submission_data(db_session, submission_id)
+
+
+@shared_task
 def export_submission_data(submission_id):
     db_session = FLASK_DB.session
     _export_submission_data(db_session, submission_id)

--- a/app/model/tasks/submissions.py
+++ b/app/model/tasks/submissions.py
@@ -18,6 +18,9 @@ def run_post_submission_jobs(submission_id):
     submission = db_session.get(Submission, submission_id)
     study = submission.study
 
+    if study.isPublished:
+        _export_submission_data(db_session, submission_id)
+
     if submission.jobStatuses.get('calculateAverages') == 'pending':
         for experiment in study.experiments:
             create_average_measurements(db_session, study, experiment)
@@ -34,9 +37,6 @@ def run_post_submission_jobs(submission_id):
         submission.jobStatuses['calculateGrowthrates'] = 'ready'
         flag_modified(submission, 'jobStatuses')
         db_session.commit()
-
-    if study.isPublished:
-        _export_submission_data(db_session, submission_id)
 
 
 @shared_task

--- a/app/model/tasks/submissions.py
+++ b/app/model/tasks/submissions.py
@@ -1,4 +1,5 @@
 import sqlalchemy as sql
+from sqlalchemy.orm.attributes import flag_modified
 from celery import shared_task
 from celery.utils.log import get_task_logger
 
@@ -16,9 +17,18 @@ def run_post_submission_jobs(submission_id):
     submission = db_session.get(Submission, submission_id)
     study = submission.study
 
-    for experiment in study.experiments:
-        create_average_measurements(db_session, study, experiment)
-    db_session.commit()
+    if submission.jobStatuses.get('calculateAverages') == 'pending':
+        for experiment in study.experiments:
+            create_average_measurements(db_session, study, experiment)
+
+        submission.jobStatuses['calculateAverages'] = 'ready'
+        flag_modified(submission, 'jobStatuses')
+
+        db_session.commit()
+
+    if submission.jobStatuses.get('calculateGrowthrates') == 'pending':
+        # TODO (2026-08-02)
+        pass
 
     if study.isPublished:
         _export_submission_data(db_session, submission_id)

--- a/app/model/tasks/submissions.py
+++ b/app/model/tasks/submissions.py
@@ -6,7 +6,7 @@ from celery.utils.log import get_task_logger
 from db import FLASK_DB
 from app.model.orm import Submission, Study
 from app.model.lib.average_measurements import create_average_measurements
-from app.model.lib.study_growth_rates import calculate_growth_rate
+from app.model.lib.batch_growth_rates import calculate_growth_rate
 
 _LOGGER = get_task_logger(__name__)
 

--- a/app/model/tasks/submissions.py
+++ b/app/model/tasks/submissions.py
@@ -4,14 +4,13 @@ from celery.utils.log import get_task_logger
 
 from db import FLASK_DB
 from app.model.orm import Submission, Study
+from app.model.lib.average_measurements import create_average_measurements
 
 _LOGGER = get_task_logger(__name__)
 
 
 @shared_task
 def run_post_submission_jobs(submission_id):
-    from app.model.lib.submission_process import create_average_measurements
-
     db_session = FLASK_DB.session
 
     submission = db_session.get(Submission, submission_id)

--- a/app/pages/upload.py
+++ b/app/pages/upload.py
@@ -248,6 +248,8 @@ def upload_step6_page(id):
         if request.files['data-template']:
             submission.dataFile = ExcelFile.from_upload(request.files['data-template'])
 
+        submission_form.update_calculations(request.form)
+
         submission.changelogText = request.form.get('changelogText')
         submission_form.save()
 

--- a/app/view/css/study.css
+++ b/app/view/css/study.css
@@ -67,8 +67,21 @@
     gap: 20px;
     margin-top: 20px;
 
-    .measurement-context-container {
+    ul.measurement-contexts {
+      list-style: none;
+      padding-left: 4px;
+    }
+
+    li.measurement-context-container {
       margin-top: 6px;
+      padding-left: 6px;
+      padding-top: 2px;
+      padding-bottom: 2px;
+      border-left: 2px solid var(--dark-blue);
+    }
+
+    ul.modeling-results {
+      padding-left: 24px;
     }
 
     .bioreplicates-list li {

--- a/app/view/forms/submission_form.py
+++ b/app/view/forms/submission_form.py
@@ -40,6 +40,9 @@ DEFAULT_STUDY_DESIGN = {
     'compartments':   [],
     'communities':    [],
     'experiments':    [],
+
+    'calculateAverages':    True,
+    'calculateGrowthrates': True,
 }
 """
 The structure of a Submission's `studyDesign` field. Any parameters given to
@@ -223,6 +226,18 @@ class SubmissionForm:
             del study_design['csrf_token']
 
         self.submission.studyDesign = study_design
+
+    def update_calculations(self, data):
+        self.submission.jobStatuses = {}
+
+        for flag in ('calculateAverages', 'calculateGrowthrates'):
+            if data.get(flag, False):
+                self.submission.studyDesign[flag] = True
+                self.submission.jobStatuses[flag] = 'pending'
+            else:
+                self.submission.studyDesign[flag] = False
+
+        flag_modified(self.submission, 'jobStatuses')
 
     def fetch_taxa(self):
         strains = self.submission.studyDesign['strains']

--- a/app/view/js/lib/compare_buttons.js
+++ b/app/view/js/lib/compare_buttons.js
@@ -24,7 +24,6 @@ function initCompareButtons($page) {
     ) {
       $container.find('.js-uncompare').removeClass('hidden');
       $container.find('.js-compare').addClass('hidden');
-      $container.parents('.js-table-row').addClass('highlight');
     }
   });
 
@@ -42,9 +41,6 @@ function initCompareButtons($page) {
       // Hide "compare" button, show "uncompare" button
       $wrapper.addClass('hidden');
       $container.find('.js-uncompare').removeClass('hidden');
-
-      // Highlight compared row
-      $container.parents('.js-table-row').addClass('highlight');
     });
   });
 

--- a/app/view/js/study.js
+++ b/app/view/js/study.js
@@ -51,6 +51,7 @@ Page('.study-page', function($page) {
       success: function(response) {
         $experiments.html(response);
         $searchInput.removeClass('loading-input');
+        initTooltips();
       }
     });
   }

--- a/app/view/js/upload/step7.js
+++ b/app/view/js/upload/step7.js
@@ -1,0 +1,3 @@
+Page('.upload-page .step-content.step-7.active', function($step7) {
+  // TODO
+});

--- a/app/view/templates/pages/experiments/_bioreplicates_list.html
+++ b/app/view/templates/pages/experiments/_bioreplicates_list.html
@@ -68,13 +68,14 @@
             {% endif %}
           </strong>
 
-          <ul class="measurement-techniques">
+          <ul class="measurement-contexts">
             {% for measurement_context in measurement_contexts: %}
-              <li class="measurement-context-container">
+              <li
+                  class="measurement-context-container {{ "highlight" if search and search.context_matches(measurement_context) }}">
                 {% set measurements = measurement_context.measurements %}
                 {% set technique    = measurement_context.technique %}
 
-                <div class="js-table-row {{ "highlight" if search and search.context_matches(measurement_context) }}">
+                <div class="js-table-row">
                   <div class="button-group" style="display: inline-block; margin-right: 6px;">
                     <span class="js-compare-container" data-context-ids="{{ measurement_context.id }}">
                       <span class="js-compare">
@@ -117,70 +118,78 @@
                   </div>
 
                   {{ measurement_context.get_chart_label() }}
-
-                  {% if measurement_context.growthRate: %}
-                    <span>μ<sub>max</sub>: {{ measurement_context.growthRate }}</span>
-                  {% endif %}
                 </div>
 
+                {% if measurement_context.growthRate: %}
+                  <div>
+                    μ<sub>max</sub> = {{ measurement_context.growthRate }} h<sup>-1</sup>
+                    <span
+                        class="icon icon-inline icon-small icon-info-gray"
+                        data-tooltip="Maximum growth rate, estimated with the &quot;Easy Linear&quot; method. Read more about it in the help documentation.">
+                    </span>
+                  </div>
+                {% endif %}
+
                 {% if measurement_context.publishedModelingResults: %}
-                  <h4 class="small">Models:</h4>
+                  <div>
+                    <strong class="small">Models:</strong>
 
-                  <ul class="small">
-                    {% for modeling_result in measurement_context.publishedModelingResults: %}
-                      <li class="{{ "highlight" if search and search.modeling_result_matches(modeling_result) }}">
-                        <div class="button-group" style="display: inline-block; margin-right: 6px;">
-                          <span class="js-compare-container" data-model-ids="{{ modeling_result.id }}">
-                            <span class="js-compare" data-tooltip="Compare">
-                              <a
-                                  href="#"
-                                  class="white-button small-button"
-                                  style="vertical-align: bottom"
-                                  data-tooltip="Compare">
-                                <span class="flex-row icon icon-arrows-diff"></span>
-                              </a>
+                    <ul class="modeling-results small">
+                      {% for modeling_result in measurement_context.publishedModelingResults: %}
+                        <li class="{{ "highlight" if search and search.modeling_result_matches(modeling_result) }}">
+                          <div class="button-group" style="display: inline-block; margin-right: 6px;">
+                            <span class="js-compare-container" data-model-ids="{{ modeling_result.id }}">
+                              <span class="js-compare" data-tooltip="Compare">
+                                <a
+                                    href="#"
+                                    class="white-button small-button"
+                                    style="vertical-align: bottom"
+                                    data-tooltip="Compare">
+                                  <span class="flex-row icon icon-arrows-diff"></span>
+                                </a>
+                              </span>
+
+                              <span class="js-uncompare uncompare hidden">
+                                <a
+                                    href="#"
+                                    class="white-button small-button"
+                                    style="vertical-align: bottom"
+                                    data-tooltip="Comparing, click to remove from comparison">
+                                  <span class="flex-row icon icon-arrows-left-right"></span>
+                                </a>
+                              </span>
                             </span>
 
-                            <span class="js-uncompare uncompare hidden">
-                              <a
-                                  href="#"
-                                  class="white-button small-button"
-                                  style="vertical-align: bottom"
-                                  data-tooltip="Comparing, click to remove from comparison">
-                                <span class="flex-row icon icon-arrows-left-right"></span>
-                              </a>
-                            </span>
-                          </span>
-
-                          {% set visualize_url = url_for(
+                            {% set visualize_url = url_for(
                             'study_visualize_page',
                             publicId=study.publicId,
                             selectedExperimentId=experiment.publicId,
                             selectedTechniqueId=technique.id,
                             l=measurement_context.id,
                             lm=modeling_result.id
-                          ) %}
+                            ) %}
 
-                          <a
-                              href="{{ visualize_url }}"
-                              class="white-button small-button"
-                              data-tooltip="Visualize">
-                            <span class="flex-row icon icon-chart"></span>
-                          </a>
+                            <a
+                                href="{{ visualize_url }}"
+                                class="white-button small-button"
+                                data-tooltip="Visualize">
+                              <span class="flex-row icon icon-chart"></span>
+                            </a>
 
-                          <a
-                              href="{{ url_for('model_prediction_csv', id=modeling_result.id) }}"
-                              class="white-button small-button"
-                              download="model_predictions_{{ modeling_result.id }}.csv"
-                              data-tooltip="Download model predictions">
-                            <span class="flex-row icon icon-download-black"></span>
-                          </a>
-                        </div>
+                            <a
+                                href="{{ url_for('model_prediction_csv', id=modeling_result.id) }}"
+                                class="white-button small-button"
+                                download="model_predictions_{{ modeling_result.id }}.csv"
+                                data-tooltip="Download model predictions">
+                              <span class="flex-row icon icon-download-black"></span>
+                            </a>
+                          </div>
 
-                        {{ modeling_result.model_name }}
-                      </li>
-                    {% endfor %}
-                  </ul>
+                          {{ modeling_result.model_name }}
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  </div>
                 {% endif %}
               </li>
             {% endfor %}

--- a/app/view/templates/pages/experiments/_bioreplicates_list.html
+++ b/app/view/templates/pages/experiments/_bioreplicates_list.html
@@ -117,6 +117,10 @@
                   </div>
 
                   {{ measurement_context.get_chart_label() }}
+
+                  {% if measurement_context.growthRate: %}
+                    <span>μ<sub>max</sub>: {{ measurement_context.growthRate }}</span>
+                  {% endif %}
                 </div>
 
                 {% if measurement_context.publishedModelingResults: %}

--- a/app/view/templates/pages/upload/step6/_form.html
+++ b/app/view/templates/pages/upload/step6/_form.html
@@ -110,13 +110,51 @@
     {% endif %}
   </div>
 
-  <br>
-
   <form
       class="simple-form step-form js-step-form"
       enctype="multipart/form-data"
       method="POST"
       action="{{ url_for('upload_step6_page', id=submission.id) }}">
+
+    <h3>Post-processing</h3>
+
+    <p>
+      Choose the actions to take after the data upload is done. These will be
+      performed in the background, and in the next step, you'll see their
+      status.
+    </p>
+
+    <label class="flex-row flex-gap-10">
+      <input
+          type="checkbox"
+          class="flex-start"
+          name="calculateAverages"
+          {{ "checked" if submission.studyDesign['calculateAverages'] }} />
+      <div>
+        Calculate averages
+        <p class="help small">
+          Biological replicates within an experiment will be averaged into an
+          "Average([experiment name])" bioreplicate record, as long as more than
+          half of their time points align. If only some time points are missing,
+          they will also be skipped in the average bioreplicate.
+        </p>
+      </div>
+    </label>
+
+    <label class="flex-row flex-gap-10">
+      <input
+          type="checkbox"
+          class="flex-start"
+          name="calculateGrowthrates"
+          {{ "checked" if submission.studyDesign['calculateGrowthrates'] }} />
+      <div>
+        Estimate growth rates
+        <p class="help small">
+          Maximum growth rates for <strong>batch</strong> experiments that measure strain or community growth will be estimated based on the "{{ "modeling-techniques"|help_link(text="Easy Linear", section="easy_linear") }}" method. Only data traces with at least <strong>6 observations</strong> will be analyzed.
+        </p>
+      </div>
+    </label>
+
     <input
         id="data-template-input"
         type="file"

--- a/app/view/templates/pages/upload/step7/_form.html
+++ b/app/view/templates/pages/upload/step7/_form.html
@@ -87,6 +87,40 @@
 
     {% endif %}
 
+    {% if submission.jobStatuses: %}
+      <h3>Post-submission tasks</h3>
+
+      <p class="help small margin-top-0">
+        These tasks will run in the background and, when finished, will update
+        your study with the calculated data. They may take some time, but you
+        can view your study in the meantime.
+      </p>
+
+      <ul class="margin-top-0">
+        {% for job, state in submission.jobStatuses.items(): %}
+          <li>
+            <span
+                data-job="{{ job }}"
+                data-state="{{ state }}">
+              {% if state == 'ready': %}
+                <span data-tooltip="Ready">✅</span>
+              {% elif state == 'pending': %}
+                <span data-tooltip="Pending">⏳</span>
+              {% elif state == 'error': %}
+                <span data-tooltip="Error, please try resubmitting later, or reach out to us, since something unexpected has happened.">❌</span>
+              {% endif %}
+            </span>
+
+            {% if job == 'calculateAverages': %}
+              Calculating averages
+            {% elif job == 'calculateGrowthrates': %}
+              Estimating maximum growth rates
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
     <br>
 
     {% if submission.study is none or not submission.study.isPublished: %}

--- a/db/migrations/2026_08_01_115108_add_job_statuses_to_submissions.py
+++ b/db/migrations/2026_08_01_115108_add_job_statuses_to_submissions.py
@@ -1,0 +1,22 @@
+import sqlalchemy as sql
+
+
+def up(conn):
+    query = """
+        ALTER TABLE Submissions
+        ADD jobStatuses JSON NOT NULL default (json_object())
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE Submissions
+        DROP jobStatuses
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from app.model.lib.migrate import run
+    run(__file__, up, down)

--- a/db/migrations/2026_08_02_170359_add_growth_rate_to_measurement_contexts.py
+++ b/db/migrations/2026_08_02_170359_add_growth_rate_to_measurement_contexts.py
@@ -1,0 +1,22 @@
+import sqlalchemy as sql
+
+
+def up(conn):
+    query = """
+        ALTER TABLE MeasurementContexts
+        ADD growthRate decimal(20,3) DEFAULT NULL
+    """
+    conn.execute(sql.text(query))
+
+
+def down(conn):
+    query = """
+        ALTER TABLE MeasurementContexts
+        DROP growthRate
+    """
+    conn.execute(sql.text(query))
+
+
+if __name__ == "__main__":
+    from app.model.lib.migrate import run
+    run(__file__, up, down)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -510,7 +510,7 @@ CREATE TABLE Studies (
   lastSubmissionId int DEFAULT NULL,
   licenseUrl varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   publicationDate varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
-  publicationType varchar(100) COLLATE utf8mb4_bin DEFAULT NULL,
+  publicationType varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   PRIMARY KEY (publicId),
   UNIQUE KEY studyUniqueID (uuid),
   KEY Studies_publicationDate (publicationDate),
@@ -640,6 +640,7 @@ CREATE TABLE Submissions (
   updatedAt datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   publishedAt datetime DEFAULT NULL,
   changelogText text,
+  jobStatuses json NOT NULL DEFAULT (json_object()),
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -846,6 +847,7 @@ INSERT INTO MigrationVersions VALUES
 (104,'2026_05_25_111809_add_workspace_entry_id_to_modeling_result','2026-05-27 14:22:49'),
 (105,'2026_06_03_164607_add_license_url_to_studies','2026-06-03 15:44:09'),
 (106,'2026_06_09_113637_add_publication_date_to_studies','2026-06-09 10:35:16'),
-(109,'2026_06_27_151530_delete_modeling_requests','2026-06-27 13:19:32'),
-(111,'2026_06_27_154711_add_publication_type_to_studies','2026-06-27 13:49:00');
+(107,'2026_06_27_151530_delete_modeling_requests','2026-06-27 13:23:03'),
+(108,'2026_06_27_154711_add_publication_type_to_studies','2026-06-27 14:14:42'),
+(110,'2026_08_01_115108_add_job_statuses_to_submissions','2026-08-01 09:56:10');
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -232,6 +232,7 @@ CREATE TABLE MeasurementContexts (
   subjectId int NOT NULL,
   subjectName varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   subjectExternalId varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  growthRate decimal(20,3) DEFAULT NULL,
   PRIMARY KEY (id),
   KEY MeasurementContexts_fk_1 (bioreplicateId),
   KEY MeasurementContexts_fk_2 (compartmentId),
@@ -849,5 +850,6 @@ INSERT INTO MigrationVersions VALUES
 (106,'2026_06_09_113637_add_publication_date_to_studies','2026-06-09 10:35:16'),
 (107,'2026_06_27_151530_delete_modeling_requests','2026-06-27 13:23:03'),
 (108,'2026_06_27_154711_add_publication_type_to_studies','2026-06-27 14:14:42'),
-(110,'2026_08_01_115108_add_job_statuses_to_submissions','2026-08-01 09:56:10');
+(110,'2026_08_01_115108_add_job_statuses_to_submissions','2026-08-01 09:56:10'),
+(112,'2026_08_02_170359_add_growth_rate_to_measurement_contexts','2026-08-02 15:04:46');
 

--- a/scripts/calculate_growth_rates.py
+++ b/scripts/calculate_growth_rates.py
@@ -1,0 +1,28 @@
+import sqlalchemy as sql
+from long_task_printer import print_with_time, LongTask
+
+from db import get_session
+from app.model.orm import Study
+from app.model.lib.batch_growth_rates import growth_can_be_estimated, calculate_growth_rate
+
+with get_session() as db_session:
+    studies = db_session.scalars(
+        sql.select(Study)
+        .order_by(Study.publicId)
+    ).all()
+
+    for study in studies:
+        with print_with_time(f"> Estimating growth rates for {study.publicId}"):
+            targets = []
+
+            for experiment in study.experiments:
+                for measurement_context in experiment.measurementContexts:
+                    if growth_can_be_estimated(experiment, measurement_context):
+                        targets.append((experiment, measurement_context))
+
+            long_task = LongTask(total_count=len(targets))
+
+            for (experiment, measurement_context) in targets:
+                with long_task.measure() as progress:
+                    print(f"  [{progress}] {measurement_context.get_chart_label()}")
+                    calculate_growth_rate(db_session, experiment, measurement_context)

--- a/scripts/modeling/baranyi_roberts.R
+++ b/scripts/modeling/baranyi_roberts.R
@@ -1,5 +1,5 @@
-library("growthrates")
-library("jsonlite")
+library("growthrates", quietly=TRUE)
+library("jsonlite", quietly=TRUE)
 
 args <- commandArgs(TRUE)
 

--- a/scripts/modeling/easy_linear.R
+++ b/scripts/modeling/easy_linear.R
@@ -1,5 +1,5 @@
-library("growthrates")
-library("jsonlite")
+library("growthrates", quietly=TRUE)
+library("jsonlite", quietly=TRUE)
 
 args <- commandArgs(TRUE)
 

--- a/scripts/modeling/logistic.R
+++ b/scripts/modeling/logistic.R
@@ -1,5 +1,5 @@
-library("growthrates")
-library("jsonlite")
+library("growthrates", quietly=TRUE)
+library("jsonlite", quietly=TRUE)
 
 args <- commandArgs(TRUE)
 

--- a/tests/model/lib/test_average_measurements.py
+++ b/tests/model/lib/test_average_measurements.py
@@ -1,0 +1,117 @@
+import tests.init  # noqa: F401
+
+from tests.database_test import DatabaseTest
+from app.model.lib.average_measurements import create_average_measurements
+
+
+class TestSubmissionProcess(DatabaseTest):
+    def test_average_measurement_creation(self):
+        experiment = self.create_experiment(name="e1")
+        study = experiment.study
+
+        c1 = self.create_compartment()
+        self.create_experiment_compartment(compartmentId=c1.id, experimentId=experiment.publicId)
+
+        mt1 = self.create_measurement_technique(
+            subjectType='bioreplicate',
+            study_technique={'studyId': study.publicId},
+        )
+        mt2 = self.create_measurement_technique(
+            subjectType='metabolite',
+            study_technique={'studyId': study.publicId},
+        )
+
+        b1 = self.create_bioreplicate(name="b1", experimentId=experiment.publicId)
+        mc1 = self.create_measurement_context(
+            subjectId=b1.id,
+            subjectType='bioreplicate',
+            bioreplicateId=b1.id,
+            techniqueId=mt1.id,
+            compartmentId=c1.id,
+        )
+        for i, value in enumerate([10, 20, 30]):
+            self.create_measurement(timeInSeconds=i, value=value, contextId=mc1.id)
+
+        b2 = self.create_bioreplicate(name="b2", experimentId=experiment.publicId)
+        mc2 = self.create_measurement_context(
+            subjectId=b2.id,
+            subjectType='bioreplicate',
+            bioreplicateId=b2.id,
+            techniqueId=mt1.id,
+            compartmentId=c1.id,
+        )
+        for i, value in enumerate([20, 40, 60]):
+            self.create_measurement(timeInSeconds=i, value=value, contextId=mc2.id)
+
+        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2"})
+        create_average_measurements(self.db_session, study, experiment)
+        self.db_session.refresh(experiment)
+        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "Average(e1)"})
+
+        average_bioreplicate = next(b for b in experiment.bioreplicates if b.name == "Average(e1)")
+        self.assertEqual(average_bioreplicate.calculationType, 'average')
+        self.assertEqual([int(m.value) for m in average_bioreplicate.measurements], [15, 30, 45])
+
+        # Don't create averages if none of their time points match
+        b3 = self.create_bioreplicate(name="b3", experimentId=experiment.publicId)
+        mc3 = self.create_measurement_context(
+            subjectId=b3.id,
+            subjectType='bioreplicate',
+            bioreplicateId=b3.id,
+            techniqueId=mt1.id,
+            compartmentId=c1.id,
+            studyId=study.publicId,
+        )
+        for i, value in enumerate([30, 50, 70]):
+            # Time points offset by 3 so there's no overlap:
+            self.create_measurement(timeInSeconds=i + 3, value=value, contextId=mc3.id)
+
+        self.db_session.delete(average_bioreplicate)
+        self.db_session.flush()
+
+        self.db_session.refresh(experiment)
+
+        # Average bioreplicate doesn't get created:
+        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "b3"})
+        create_average_measurements(self.db_session, study, experiment)
+        self.db_session.refresh(experiment)
+        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "b3"})
+
+        # Delete b1, b2, b3 to avoid interfering with the next averages:
+        self.db_session.delete(b1)
+        self.db_session.delete(b2)
+        self.db_session.delete(b3)
+        self.db_session.flush()
+
+        # Don't create averages if they're one measurement context per subject
+        b4 = self.create_bioreplicate(name="b4", experimentId=experiment.publicId)
+        m1 = self.create_metabolite()
+        m2 = self.create_metabolite()
+        mc4 = self.create_measurement_context(
+            subjectId=m1.id,
+            subjectType='metabolite',
+            bioreplicateId=b4.id,
+            techniqueId=mt2.id,
+            compartmentId=c1.id,
+            studyId=study.publicId,
+        )
+        mc5 = self.create_measurement_context(
+            subjectId=m2.id,
+            subjectType='metabolite',
+            bioreplicateId=b4.id,
+            techniqueId=mt2.id,
+            compartmentId=c1.id,
+            studyId=study.publicId,
+        )
+        for i, value in enumerate([30, 50, 70]):
+            self.create_measurement(timeInSeconds=i, value=value, contextId=mc4.id)
+            self.create_measurement(timeInSeconds=i, value=value, contextId=mc5.id)
+
+        self.db_session.flush()
+        self.db_session.refresh(experiment)
+
+        # Average bioreplicate doesn't get created:
+        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b4"})
+        create_average_measurements(self.db_session, study, experiment)
+        self.db_session.refresh(experiment)
+        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b4"})

--- a/tests/model/lib/test_study_growth_rates.py
+++ b/tests/model/lib/test_study_growth_rates.py
@@ -3,7 +3,7 @@ import tests.init  # noqa: F401
 from decimal import Decimal
 
 from tests.database_test import DatabaseTest
-from app.model.lib.study_growth_rates import calculate_growth_rate
+from app.model.lib.batch_growth_rates import calculate_growth_rate
 
 
 class TestStudyGrowthRates(DatabaseTest):

--- a/tests/model/lib/test_study_growth_rates.py
+++ b/tests/model/lib/test_study_growth_rates.py
@@ -1,0 +1,88 @@
+import tests.init  # noqa: F401
+
+from decimal import Decimal
+
+from tests.database_test import DatabaseTest
+from app.model.lib.study_growth_rates import calculate_growth_rate
+
+
+class TestStudyGrowthRates(DatabaseTest):
+    def setUp(self):
+        super().setUp()
+
+        self.data = [
+            (0, 2252333),
+            (4, 27694667),
+            (8, 365293333),
+            (12, 1125370000),
+            (16, 1451296667),
+            (20, 1310296667),
+        ]
+
+    def test_no_calculation_for_non_batch_experiments(self):
+        for mode in ('fed-batch', 'chemostat', 'other'):
+            e = self.create_experiment(cultivationMode=mode)
+            b = self.create_bioreplicate(experimentId=e.publicId)
+            mc = self.create_measurement_context(bioreplicateId=b.id, growthRate=None)
+
+            self.assertFalse(calculate_growth_rate(self.db_session, e, mc))
+
+            self.db_session.refresh(mc)
+            self.assertIsNone(mc.growthRate)
+
+    def test_no_calculation_for_metabolite_measurements_or_ph(self):
+        e = self.create_experiment(cultivationMode='batch')
+        b = self.create_bioreplicate(experimentId=e.publicId)
+        mc1 = self.create_measurement_context(
+            bioreplicateId=b.id,
+            growthRate=None,
+            subjectType='metabolite',
+            subjectId=self.create_metabolite().id,
+        )
+        mc2 = self.create_measurement_context(
+            bioreplicateId=b.id,
+            growthRate=None,
+            subjectType='bioreplicate',
+            subjectId=b.id,
+            techniqueId=self.create_measurement_technique(type='ph').id,
+        )
+        for time, value in self.data:
+            self.create_measurement(contextId=mc1.id, timeInSeconds=(time * 3600), value=value)
+            self.create_measurement(contextId=mc2.id, timeInSeconds=(time * 3600), value=value)
+
+        for mc in [mc1, mc2]:
+            self.assertFalse(calculate_growth_rate(self.db_session, e, mc))
+            self.db_session.refresh(mc)
+            self.assertIsNone(mc.growthRate)
+
+    def test_growth_rate_calculation(self):
+        e = self.create_experiment(cultivationMode='batch')
+        b = self.create_bioreplicate(experimentId=e.publicId)
+        mc = self.create_measurement_context(
+            bioreplicateId=b.id,
+            subjectType='bioreplicate',
+            subjectId=b.id,
+            growthRate=None,
+        )
+        for time, value in self.data:
+            self.create_measurement(contextId=mc.id, timeInSeconds=(time * 3600), value=value)
+
+        self.assertTrue(calculate_growth_rate(self.db_session, e, mc))
+
+        self.db_session.refresh(mc)
+        self.assertEqual(mc.growthRate, Decimal('0.416'))
+
+        # A minimum of 6 points are required:
+        mc2 = self.create_measurement_context(
+            bioreplicateId=b.id,
+            subjectType='bioreplicate',
+            subjectId=b.id,
+            growthRate=None,
+        )
+        small_data = self.data[0:-2]
+        for time, value in small_data:
+            self.create_measurement(contextId=mc2.id, timeInSeconds=(time * 3600), value=value)
+
+        self.assertFalse(calculate_growth_rate(self.db_session, e, mc2))
+        self.db_session.refresh(mc2)
+        self.assertIsNone(mc2.growthRate)

--- a/tests/model/lib/test_submission_process.py
+++ b/tests/model/lib/test_submission_process.py
@@ -17,6 +17,7 @@ from app.model.orm import (
 )
 from app.view.forms.submission_form import SubmissionForm
 from app.model.lib.submission_process import (
+    create_average_measurements,
     _clear_study,
     _save_project,
     _save_study,
@@ -24,7 +25,6 @@ from app.model.lib.submission_process import (
     _save_communities,
     _save_experiments,
     _save_study_techniques,
-    _create_average_measurements,
     _finalize_submission,
 )
 from tests.database_test import DatabaseTest
@@ -499,7 +499,7 @@ class TestSubmissionProcess(DatabaseTest):
             self.create_measurement(timeInSeconds=i, value=value, contextId=mc2.id)
 
         self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2"})
-        _create_average_measurements(self.db_session, study, experiment)
+        create_average_measurements(self.db_session, study, experiment)
         self.db_session.refresh(experiment)
         self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "Average(e1)"})
 
@@ -528,7 +528,7 @@ class TestSubmissionProcess(DatabaseTest):
 
         # Average bioreplicate doesn't get created:
         self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "b3"})
-        _create_average_measurements(self.db_session, study, experiment)
+        create_average_measurements(self.db_session, study, experiment)
         self.db_session.refresh(experiment)
         self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "b3"})
 
@@ -567,7 +567,7 @@ class TestSubmissionProcess(DatabaseTest):
 
         # Average bioreplicate doesn't get created:
         self.assertEqual({b.name for b in experiment.bioreplicates}, {"b4"})
-        _create_average_measurements(self.db_session, study, experiment)
+        create_average_measurements(self.db_session, study, experiment)
         self.db_session.refresh(experiment)
         self.assertEqual({b.name for b in experiment.bioreplicates}, {"b4"})
 

--- a/tests/model/lib/test_submission_process.py
+++ b/tests/model/lib/test_submission_process.py
@@ -17,7 +17,6 @@ from app.model.orm import (
 )
 from app.view.forms.submission_form import SubmissionForm
 from app.model.lib.submission_process import (
-    create_average_measurements,
     _clear_study,
     _save_project,
     _save_study,
@@ -459,117 +458,6 @@ class TestSubmissionProcess(DatabaseTest):
         self.assertEqual(len(techniques), 3)
         self.assertEqual(techniques, study.studyTechniques)
         self.assertEqual({m.name for m in study.metabolites}, {'pyruvate', 'butyrate'})
-
-    def test_average_measurement_creation(self):
-        experiment = self.create_experiment(name="e1")
-        study = experiment.study
-
-        c1 = self.create_compartment()
-        self.create_experiment_compartment(compartmentId=c1.id, experimentId=experiment.publicId)
-
-        mt1 = self.create_measurement_technique(
-            subjectType='bioreplicate',
-            study_technique={'studyId': study.publicId},
-        )
-        mt2 = self.create_measurement_technique(
-            subjectType='metabolite',
-            study_technique={'studyId': study.publicId},
-        )
-
-        b1 = self.create_bioreplicate(name="b1", experimentId=experiment.publicId)
-        mc1 = self.create_measurement_context(
-            subjectId=b1.id,
-            subjectType='bioreplicate',
-            bioreplicateId=b1.id,
-            techniqueId=mt1.id,
-            compartmentId=c1.id,
-        )
-        for i, value in enumerate([10, 20, 30]):
-            self.create_measurement(timeInSeconds=i, value=value, contextId=mc1.id)
-
-        b2 = self.create_bioreplicate(name="b2", experimentId=experiment.publicId)
-        mc2 = self.create_measurement_context(
-            subjectId=b2.id,
-            subjectType='bioreplicate',
-            bioreplicateId=b2.id,
-            techniqueId=mt1.id,
-            compartmentId=c1.id,
-        )
-        for i, value in enumerate([20, 40, 60]):
-            self.create_measurement(timeInSeconds=i, value=value, contextId=mc2.id)
-
-        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2"})
-        create_average_measurements(self.db_session, study, experiment)
-        self.db_session.refresh(experiment)
-        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "Average(e1)"})
-
-        average_bioreplicate = next(b for b in experiment.bioreplicates if b.name == "Average(e1)")
-        self.assertEqual(average_bioreplicate.calculationType, 'average')
-        self.assertEqual([int(m.value) for m in average_bioreplicate.measurements], [15, 30, 45])
-
-        # Don't create averages if none of their time points match
-        b3 = self.create_bioreplicate(name="b3", experimentId=experiment.publicId)
-        mc3 = self.create_measurement_context(
-            subjectId=b3.id,
-            subjectType='bioreplicate',
-            bioreplicateId=b3.id,
-            techniqueId=mt1.id,
-            compartmentId=c1.id,
-            studyId=study.publicId,
-        )
-        for i, value in enumerate([30, 50, 70]):
-            # Time points offset by 3 so there's no overlap:
-            self.create_measurement(timeInSeconds=i + 3, value=value, contextId=mc3.id)
-
-        self.db_session.delete(average_bioreplicate)
-        self.db_session.flush()
-
-        self.db_session.refresh(experiment)
-
-        # Average bioreplicate doesn't get created:
-        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "b3"})
-        create_average_measurements(self.db_session, study, experiment)
-        self.db_session.refresh(experiment)
-        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b1", "b2", "b3"})
-
-        # Delete b1, b2, b3 to avoid interfering with the next averages:
-        self.db_session.delete(b1)
-        self.db_session.delete(b2)
-        self.db_session.delete(b3)
-        self.db_session.flush()
-
-        # Don't create averages if they're one measurement context per subject
-        b4 = self.create_bioreplicate(name="b4", experimentId=experiment.publicId)
-        m1 = self.create_metabolite()
-        m2 = self.create_metabolite()
-        mc4 = self.create_measurement_context(
-            subjectId=m1.id,
-            subjectType='metabolite',
-            bioreplicateId=b4.id,
-            techniqueId=mt2.id,
-            compartmentId=c1.id,
-            studyId=study.publicId,
-        )
-        mc5 = self.create_measurement_context(
-            subjectId=m2.id,
-            subjectType='metabolite',
-            bioreplicateId=b4.id,
-            techniqueId=mt2.id,
-            compartmentId=c1.id,
-            studyId=study.publicId,
-        )
-        for i, value in enumerate([30, 50, 70]):
-            self.create_measurement(timeInSeconds=i, value=value, contextId=mc4.id)
-            self.create_measurement(timeInSeconds=i, value=value, contextId=mc5.id)
-
-        self.db_session.flush()
-        self.db_session.refresh(experiment)
-
-        # Average bioreplicate doesn't get created:
-        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b4"})
-        create_average_measurements(self.db_session, study, experiment)
-        self.db_session.refresh(experiment)
-        self.assertEqual({b.name for b in experiment.bioreplicates}, {"b4"})
 
     def test_updating_study_before_publication(self):
         study = self.create_study(publishedAt=None)

--- a/tests/view/forms/test_submission_form.py
+++ b/tests/view/forms/test_submission_form.py
@@ -188,6 +188,35 @@ class TestSubmissionForm(DatabaseTest):
             ['glucose', 'trehalose'],
         )
 
+    def test_calculation_flags(self):
+        submission_form = SubmissionForm.create(db_session=self.db_session, user_uuid='test_user')
+        submission = submission_form.submission
+
+        # By default, we calculate everything
+        self.assertTrue(submission.studyDesign['calculateAverages'])
+        self.assertTrue(submission.studyDesign['calculateGrowthrates'])
+        self.assertEqual(submission.jobStatuses, {})
+
+        submission_form.update_calculations({'calculateAverages': False, 'calculateGrowthrates': True})
+
+        self.assertFalse(submission.studyDesign['calculateAverages'])
+        self.assertTrue(submission.studyDesign['calculateGrowthrates'])
+        self.assertEqual(submission.jobStatuses, {'calculateGrowthrates': 'pending'})
+
+        # Missing flags means being set to False:
+        submission_form.update_calculations({'calculateAverages': True})
+
+        self.assertTrue(submission_form.submission.studyDesign['calculateAverages'])
+        self.assertFalse(submission_form.submission.studyDesign['calculateGrowthrates'])
+        self.assertEqual(submission.jobStatuses, {'calculateAverages': 'pending'})
+
+        # Stringy arguments (from checkboxes) are also True:
+        submission_form.update_calculations({'calculateGrowthrates': 'on'})
+
+        self.assertFalse(submission_form.submission.studyDesign['calculateAverages'])
+        self.assertTrue(submission_form.submission.studyDesign['calculateGrowthrates'])
+        self.assertEqual(submission.jobStatuses, {'calculateGrowthrates': 'pending'})
+
     def test_technique_descriptions(self):
         submission_form = SubmissionForm.create(db_session=self.db_session, user_uuid='test_user')
 


### PR DESCRIPTION
This PR adds a "post-submission" section to step 6 of the upload process where people can pick calculations for us to do after their data is uploaded. This includes estimating growth rates using the "Easy linear" method, which takes some time, but now that it's in the background, it should be fine.

In the future, it would be nice to rewrite the easy linear calculation in python or find a package that does it, because it's not too complicated and it would avoid shelling out a lot to R. Potentially, I could run the calculation in batches, too. But these are optimizations that are not critical.

Demo video: https://www.youtube.com/watch?v=F5mMZI-_AaU. (Correction: at some point I say that the abundance at time 0 is 0. On rewatch, I realize I misread that. So, when growth rate fitting doesn't work, it's *probably* for the ones where the abundance is 0 at some point)